### PR TITLE
Use assertEqual everywhere in tests, assertEquals is deprecated in 3

### DIFF
--- a/test/test_common.py
+++ b/test/test_common.py
@@ -56,10 +56,10 @@ class CommonTest(unittest.TestCase):
         ctx = googlemaps.Context(key="AIzaasdf")
         googlemaps.geocode(ctx, "Sesame St.")
 
-        self.assertEquals(1, len(responses.calls))
+        self.assertEqual(1, len(responses.calls))
 
         url = urlparse(responses.calls[0].request.url)
-        self.assertEquals("key=AIzaasdf&address=Sesame+St.", url.query)
+        self.assertEqual("key=AIzaasdf&address=Sesame+St.", url.query)
 
     def test_hmac(self):
         """
@@ -73,7 +73,7 @@ class CommonTest(unittest.TestCase):
         key = "a2V5" # "key" -> base64
         signature = "3nybhbi3iqa8ino29wqQcBydtNk="
 
-        self.assertEquals(signature, common._hmac_sign(key, message))
+        self.assertEqual(signature, common._hmac_sign(key, message))
 
     @responses.activate
     def test_url_signed(self):
@@ -86,11 +86,11 @@ class CommonTest(unittest.TestCase):
         ctx = googlemaps.Context(client_id="foo", client_secret="a2V5")
         googlemaps.geocode(ctx, "Sesame St.")
 
-        self.assertEquals(1, len(responses.calls))
+        self.assertEqual(1, len(responses.calls))
 
         url = urlparse(responses.calls[0].request.url)
         expected = "client=foo&address=Sesame+St.&signature=Ao1r8ULP1g_vPwnf7Fvf2TSCYBQ="
-        self.assertEquals(expected, url.query)
+        self.assertEqual(expected, url.query)
 
     @responses.activate
     def test_ua_sent(self):
@@ -103,7 +103,7 @@ class CommonTest(unittest.TestCase):
         ctx = googlemaps.Context(key="AIzaasdf")
         googlemaps.geocode(ctx, "Sesame St.")
 
-        self.assertEquals(1, len(responses.calls))
+        self.assertEqual(1, len(responses.calls))
         user_agent = responses.calls[0].request.headers["User-Agent"]
         self.assertTrue(user_agent.startswith("GoogleGeoApiClientPython"))
 
@@ -127,7 +127,7 @@ class CommonTest(unittest.TestCase):
         ctx = googlemaps.Context(key="AIzaasdf")
         googlemaps.geocode(ctx, "Sesame St.")
 
-        self.assertEquals(2, len(responses.calls))
+        self.assertEqual(2, len(responses.calls))
 
     @responses.activate
     def test_retry_intermittent(self):
@@ -149,4 +149,4 @@ class CommonTest(unittest.TestCase):
         ctx = googlemaps.Context(key="AIzaasdf")
         googlemaps.geocode(ctx, "Sesame St.")
 
-        self.assertEquals(2, len(responses.calls))
+        self.assertEqual(2, len(responses.calls))

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -42,35 +42,35 @@ class ConvertTest(unittest.TestCase):
             convert.latlng("test")
 
     def test_join_list(self):
-        self.assertEquals("asdf", convert.join_list("|", "asdf"))
+        self.assertEqual("asdf", convert.join_list("|", "asdf"))
 
-        self.assertEquals("1,2,A", convert.join_list(",", ["1", "2", "A"]))
+        self.assertEqual("1,2,A", convert.join_list(",", ["1", "2", "A"]))
 
-        self.assertEquals("", convert.join_list(",", []))
+        self.assertEqual("", convert.join_list(",", []))
 
-        self.assertEquals("a,B", convert.join_list(",", ("a", "B")))
+        self.assertEqual("a,B", convert.join_list(",", ("a", "B")))
 
     def test_as_list(self):
-        self.assertEquals([1], convert.as_list(1))
+        self.assertEqual([1], convert.as_list(1))
 
-        self.assertEquals([1, 2, 3], convert.as_list([1, 2, 3]))
+        self.assertEqual([1, 2, 3], convert.as_list([1, 2, 3]))
 
-        self.assertEquals(["string"], convert.as_list("string"))
+        self.assertEqual(["string"], convert.as_list("string"))
 
-        self.assertEquals((1, 2), convert.as_list((1, 2)))
+        self.assertEqual((1, 2), convert.as_list((1, 2)))
 
     def test_time(self):
-        self.assertEquals("1409810596", convert.time(1409810596))
+        self.assertEqual("1409810596", convert.time(1409810596))
 
         dt = datetime.datetime.fromtimestamp(1409810596)
-        self.assertEquals("1409810596", convert.time(dt))
+        self.assertEqual("1409810596", convert.time(dt))
 
     def test_components(self):
         c = {"country": "US"}
-        self.assertEquals("country:US", convert.components(c))
+        self.assertEqual("country:US", convert.components(c))
 
         c = {"country": "US", "foo": 1}
-        self.assertEquals("country:US|foo:1", convert.components(c))
+        self.assertEqual("country:US|foo:1", convert.components(c))
 
         with self.assertRaises(TypeError):
             convert.components("test")
@@ -85,7 +85,7 @@ class ConvertTest(unittest.TestCase):
         ne = {"lat": 1, "lng": 2}
         sw = (3, 4)
         b = {"northeast": ne, "southwest": sw}
-        self.assertEquals("3.000000,4.000000|1.000000,2.000000",
+        self.assertEqual("3.000000,4.000000|1.000000,2.000000",
                           convert.bounds(b))
 
         with self.assertRaises(TypeError):
@@ -119,10 +119,10 @@ class ConvertTest(unittest.TestCase):
                          "C~w@hnB{e@yF}`D`_Ayx@~vGqn@l}CafC")
 
         points = convert.decode_polyline(syd_mel_route)
-        self.assertAlmostEquals(-33.86746, points[0]["lat"])
-        self.assertAlmostEquals(151.207090, points[0]["lng"])
-        self.assertAlmostEquals(-37.814130, points[-1]["lat"])
-        self.assertAlmostEquals(144.963180, points[-1]["lng"])
+        self.assertAlmostEqual(-33.86746, points[0]["lat"])
+        self.assertAlmostEqual(151.207090, points[0]["lng"])
+        self.assertAlmostEqual(-37.814130, points[-1]["lat"])
+        self.assertAlmostEqual(144.963180, points[-1]["lng"])
 
     def test_polyline_round_trip(self):
         test_polyline = ("gcneIpgxzRcDnBoBlEHzKjBbHlG`@`IkDxIi"
@@ -130,4 +130,4 @@ class ConvertTest(unittest.TestCase):
 
         points = convert.decode_polyline(test_polyline)
         actual_polyline = convert.encode_polyline(points)
-        self.assertEquals(test_polyline, actual_polyline)
+        self.assertEqual(test_polyline, actual_polyline)

--- a/test/test_directions.py
+++ b/test/test_directions.py
@@ -42,8 +42,8 @@ class DirectionsTest(unittest.TestCase):
         routes = googlemaps.directions(self.ctx,
                                        "Sydney", "Melbourne")
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/directions/json'
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/directions/json'
                           '?origin=Sydney&destination=Melbourne&key=%s' %
                           self.key,
                           responses.calls[0].request.url)
@@ -64,13 +64,13 @@ class DirectionsTest(unittest.TestCase):
                                        units="metric",
                                        region="us")
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/directions/json?'
-                          'origin=Sydney&avoid=highways%%7Ctolls%%7Cferries&'
-                          'destination=Melbourne&mode=bicycling&key=%s'
-                          '&units=metric&region=us' %
-                          self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/directions/json?'
+                         'origin=Sydney&avoid=highways%%7Ctolls%%7Cferries&'
+                         'destination=Melbourne&mode=bicycling&key=%s'
+                         '&units=metric&region=us' %
+                         self.key,
+                         responses.calls[0].request.url)
 
 
     def test_transit_without_time(self):
@@ -97,12 +97,12 @@ class DirectionsTest(unittest.TestCase):
                                        mode="transit",
                                        departure_time=now)
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/directions/json?origin='
-                          'Sydney+Town+Hall&key=%s&destination=Parramatta%%2C+NSW&'
-                          'mode=transit&departure_time=%d' %
-                          (self.key, time.mktime(now.timetuple())),
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/directions/json?origin='
+                         'Sydney+Town+Hall&key=%s&destination=Parramatta%%2C+NSW&'
+                         'mode=transit&departure_time=%d' %
+                         (self.key, time.mktime(now.timetuple())),
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_transit_with_arrival_time(self):
@@ -118,12 +118,12 @@ class DirectionsTest(unittest.TestCase):
                                        mode="transit",
                                        arrival_time=an_hour_from_now)
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/directions/json?'
-                          'origin=Sydney+Town+Hall&arrival_time=%d&'
-                          'destination=Parramatta%%2C+NSW&mode=transit&key=%s' %
-                          (time.mktime(an_hour_from_now.timetuple()), self.key),
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/directions/json?'
+                         'origin=Sydney+Town+Hall&arrival_time=%d&'
+                         'destination=Parramatta%%2C+NSW&mode=transit&key=%s' %
+                         (time.mktime(an_hour_from_now.timetuple()), self.key),
+                         responses.calls[0].request.url)
 
 
     def test_crazy_travel_mode(self):
@@ -144,11 +144,11 @@ class DirectionsTest(unittest.TestCase):
                                        "Parramatta, NSW",
                                        mode="bicycling")
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/directions/json?'
-                          'origin=Town+Hall%%2C+Sydney&destination=Parramatta%%2C+NSW&'
-                          'mode=bicycling&key=%s' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/directions/json?'
+                         'origin=Town+Hall%%2C+Sydney&destination=Parramatta%%2C+NSW&'
+                         'mode=bicycling&key=%s' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_brooklyn_to_queens_by_transit(self):
@@ -164,8 +164,8 @@ class DirectionsTest(unittest.TestCase):
                                        mode="transit",
                                        departure_time=now)
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/directions/json?'
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/directions/json?'
                           'origin=Brooklyn&key=%s&destination=Queens&mode=transit&'
                           'departure_time=%d' % (self.key, time.mktime(now.timetuple())),
                           responses.calls[0].request.url)
@@ -183,12 +183,12 @@ class DirectionsTest(unittest.TestCase):
                                        waypoints=["Charlestown, MA",
                                                   "Lexington, MA"])
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/directions/json?'
-                          'origin=Boston%%2C+MA&destination=Concord%%2C+MA&'
-                          'waypoints=Charlestown%%2C+MA%%7CLexington%%2C+MA&'
-                          'key=%s' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/directions/json?'
+                         'origin=Boston%%2C+MA&destination=Concord%%2C+MA&'
+                         'waypoints=Charlestown%%2C+MA%%7CLexington%%2C+MA&'
+                         'key=%s' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_adelaide_wine_tour(self):
@@ -206,13 +206,13 @@ class DirectionsTest(unittest.TestCase):
                                                   "McLaren Vale, SA"],
                                        optimize_waypoints=True)
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/directions/json?'
-                          'origin=Adelaide%%2C+SA&destination=Adelaide%%2C+SA&'
-                          'waypoints=optimize%%3Atrue%%7CBarossa+Valley%%2C+'
-                          'SA%%7CClare%%2C+SA%%7CConnawarra%%2C+SA%%7CMcLaren+'
-                          'Vale%%2C+SA&key=%s' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/directions/json?'
+                         'origin=Adelaide%%2C+SA&destination=Adelaide%%2C+SA&'
+                         'waypoints=optimize%%3Atrue%%7CBarossa+Valley%%2C+'
+                         'SA%%7CClare%%2C+SA%%7CConnawarra%%2C+SA%%7CMcLaren+'
+                         'Vale%%2C+SA&key=%s' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_toledo_to_madrid_in_spain(self):
@@ -225,11 +225,11 @@ class DirectionsTest(unittest.TestCase):
         routes = googlemaps.directions(self.ctx, "Toledo", "Madrid",
                                        region="es")
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/directions/json?'
-                          'origin=Toledo&region=es&destination=Madrid&key=%s' % 
-                          self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/directions/json?'
+                         'origin=Toledo&region=es&destination=Madrid&key=%s' % 
+                         self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_zero_results_returns_response(self):
@@ -241,7 +241,7 @@ class DirectionsTest(unittest.TestCase):
 
         routes = googlemaps.directions(self.ctx, "Toledo", "Madrid")
         self.assertIsNotNone(routes)
-        self.assertEquals(0, len(routes))
+        self.assertEqual(0, len(routes))
 
     @responses.activate
     def test_language_parameter(self):
@@ -255,11 +255,11 @@ class DirectionsTest(unittest.TestCase):
                                        region="es",
                                        language="es")
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/directions/json?'
-                          'origin=Toledo&region=es&destination=Madrid&key=%s&'
-                          'language=es' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/directions/json?'
+                         'origin=Toledo&region=es&destination=Madrid&key=%s&'
+                         'language=es' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_alternatives(self):
@@ -273,9 +273,10 @@ class DirectionsTest(unittest.TestCase):
                                        "Parramatta Town Hall",
                                        alternatives=True)
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/directions/json?'
-                          'origin=Sydney+Town+Hall&destination=Parramatta+Town+Hall&'
-                          'alternatives=true&key=%s' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/directions/json?'
+                         'origin=Sydney+Town+Hall&destination=Parramatta+Town+Hall&'
+                         'alternatives=true&key=%s' % self.key,
+                         responses.calls[0].request.url)
+                         
 

--- a/test/test_distance_matrix.py
+++ b/test/test_distance_matrix.py
@@ -47,16 +47,16 @@ class DistanceMatrixTest(unittest.TestCase):
 
         matrix = googlemaps.distance_matrix(self.ctx, origins, destinations)
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/distancematrix/json?'
-                          'key=%s&origins=Perth%%2C+Australia%%7CSydney%%2C+'
-                          'Australia%%7CMelbourne%%2C+Australia%%7CAdelaide%%2C+'
-                          'Australia%%7CBrisbane%%2C+Australia%%7CDarwin%%2C+'
-                          'Australia%%7CHobart%%2C+Australia%%7CCanberra%%2C+Australia&'
-                          'destinations=Uluru%%2C+Australia%%7CKakadu%%2C+Australia%%7C'
-                          'Blue+Mountains%%2C+Australia%%7CBungle+Bungles%%2C+Australia'
-                          '%%7CThe+Pinnacles%%2C+Australia' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/distancematrix/json?'
+                         'key=%s&origins=Perth%%2C+Australia%%7CSydney%%2C+'
+                         'Australia%%7CMelbourne%%2C+Australia%%7CAdelaide%%2C+'
+                         'Australia%%7CBrisbane%%2C+Australia%%7CDarwin%%2C+'
+                         'Australia%%7CHobart%%2C+Australia%%7CCanberra%%2C+Australia&'
+                         'destinations=Uluru%%2C+Australia%%7CKakadu%%2C+Australia%%7C'
+                         'Blue+Mountains%%2C+Australia%%7CBungle+Bungles%%2C+Australia'
+                         '%%7CThe+Pinnacles%%2C+Australia' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_mixed_params(self):
@@ -72,12 +72,12 @@ class DistanceMatrixTest(unittest.TestCase):
 
         matrix = googlemaps.distance_matrix(self.ctx, origins, destinations)
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/distancematrix/json?'
-                          'key=%s&origins=Bobcaygeon+ON%%7C41.432060%%2C-81.389920&'
-                          'destinations=43.012486%%2C-83.696415%%7C42.886386%%2C'
-                          '-78.878163' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/distancematrix/json?'
+                         'key=%s&origins=Bobcaygeon+ON%%7C41.432060%%2C-81.389920&'
+                         'destinations=43.012486%%2C-83.696415%%7C42.886386%%2C'
+                         '-78.878163' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_all_params(self):
@@ -103,17 +103,17 @@ class DistanceMatrixTest(unittest.TestCase):
                                             avoid="tolls",
                                             units="imperial")
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/distancematrix/json?'
-                          'origins=Perth%%2C+Australia%%7CSydney%%2C+Australia%%7C'
-                          'Melbourne%%2C+Australia%%7CAdelaide%%2C+Australia%%7C'
-                          'Brisbane%%2C+Australia%%7CDarwin%%2C+Australia%%7CHobart%%2C+'
-                          'Australia%%7CCanberra%%2C+Australia&language=en-AU&'
-                          'avoid=tolls&mode=driving&key=%s&units=imperial&'
-                          'destinations=Uluru%%2C+Australia%%7CKakadu%%2C+Australia%%7C'
-                          'Blue+Mountains%%2C+Australia%%7CBungle+Bungles%%2C+Australia'
-                          '%%7CThe+Pinnacles%%2C+Australia' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/distancematrix/json?'
+                         'origins=Perth%%2C+Australia%%7CSydney%%2C+Australia%%7C'
+                         'Melbourne%%2C+Australia%%7CAdelaide%%2C+Australia%%7C'
+                         'Brisbane%%2C+Australia%%7CDarwin%%2C+Australia%%7CHobart%%2C+'
+                         'Australia%%7CCanberra%%2C+Australia&language=en-AU&'
+                         'avoid=tolls&mode=driving&key=%s&units=imperial&'
+                         'destinations=Uluru%%2C+Australia%%7CKakadu%%2C+Australia%%7C'
+                         'Blue+Mountains%%2C+Australia%%7CBungle+Bungles%%2C+Australia'
+                         '%%7CThe+Pinnacles%%2C+Australia' % self.key,
+                         responses.calls[0].request.url)
 
 
     @responses.activate
@@ -131,10 +131,10 @@ class DistanceMatrixTest(unittest.TestCase):
                                             language="fr-FR",
                                             mode="bicycling")
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/distancematrix/json?'
-                          'key=%s&language=fr-FR&mode=bicycling&'
-                          'origins=Vancouver+BC%%7CSeattle&'
-                          'destinations=San+Francisco%%7CVictoria+BC' %
-                          self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/distancematrix/json?'
+                         'key=%s&language=fr-FR&mode=bicycling&'
+                         'origins=Vancouver+BC%%7CSeattle&'
+                         'destinations=San+Francisco%%7CVictoria+BC' %
+                         self.key,
+                         responses.calls[0].request.url)

--- a/test/test_elevation.py
+++ b/test/test_elevation.py
@@ -39,8 +39,8 @@ class ElevationTest(unittest.TestCase):
 
         results = googlemaps.elevation(self.ctx, (40.714728, -73.998672))
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/elevation/json?'
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/elevation/json?'
                           'locations=40.714728%%2C-73.998672&key=%s' % self.key,
                           responses.calls[0].request.url)
 
@@ -54,10 +54,10 @@ class ElevationTest(unittest.TestCase):
 
         results = googlemaps.elevation(self.ctx, [(40.714728, -73.998672)])
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/elevation/json?'
-                          'locations=40.714728%%2C-73.998672&key=%s' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/elevation/json?'
+                         'locations=40.714728%%2C-73.998672&key=%s' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_elevation_multiple(self):
@@ -70,11 +70,11 @@ class ElevationTest(unittest.TestCase):
         locations = [(40.714728, -73.998672), (-34.397, 150.644)]
         results = googlemaps.elevation(self.ctx, locations)
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/elevation/json?'
-                          'locations=40.714728%%2C-73.998672%%7C-34.397000%%2C'
-                          '150.644000&key=%s' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/elevation/json?'
+                         'locations=40.714728%%2C-73.998672%%7C-34.397000%%2C'
+                         '150.644000&key=%s' % self.key,
+                         responses.calls[0].request.url)
 
     def test_elevation_along_path_single(self):
         with self.assertRaises(googlemaps.ApiError):
@@ -94,9 +94,9 @@ class ElevationTest(unittest.TestCase):
         
         results = googlemaps.elevation_along_path(self.ctx, path, 5)
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/elevation/json?'
-                          'path=40.714728%%2C-73.998672%%7C-34.397000%%2C150.644000&'
-                          'key=%s&samples=5' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/elevation/json?'
+                         'path=40.714728%%2C-73.998672%%7C-34.397000%%2C150.644000&'
+                         'key=%s&samples=5' % self.key,
+                         responses.calls[0].request.url)
 

--- a/test/test_geocoding.py
+++ b/test/test_geocoding.py
@@ -39,8 +39,8 @@ class GeocodingTest(unittest.TestCase):
 
         results = googlemaps.geocode(self.ctx, 'Sydney')
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
                           'key=%s&address=Sydney' % self.key,
                           responses.calls[0].request.url)
 
@@ -54,10 +54,10 @@ class GeocodingTest(unittest.TestCase):
 
         results = googlemaps.reverse_geocode(self.ctx, (-33.8674869, 151.2069902))
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'latlng=-33.867487%%2C151.206990&key=%s' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'latlng=-33.867487%%2C151.206990&key=%s' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_geocoding_the_googleplex(self):
@@ -70,11 +70,11 @@ class GeocodingTest(unittest.TestCase):
         results = googlemaps.geocode(self.ctx, '1600 Amphitheatre Parkway, '
                                   'Mountain View, CA')
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'key=%s&address=1600+Amphitheatre+Parkway%%2C+Mountain'
-                          '+View%%2C+CA' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'key=%s&address=1600+Amphitheatre+Parkway%%2C+Mountain'
+                         '+View%%2C+CA' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_geocode_with_bounds(self):
@@ -88,11 +88,11 @@ class GeocodingTest(unittest.TestCase):
                                   bounds={'southwest': (34.172684, -118.604794),
                                           'northeast':(34.236144, -118.500938)})
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'bounds=34.172684%%2C-118.604794%%7C34.236144%%2C'
-                          '-118.500938&key=%s&address=Winnetka' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'bounds=34.172684%%2C-118.604794%%7C34.236144%%2C'
+                         '-118.500938&key=%s&address=Winnetka' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_geocode_with_region_biasing(self):
@@ -104,10 +104,10 @@ class GeocodingTest(unittest.TestCase):
 
         results = googlemaps.geocode(self.ctx, 'Toledo', region='es')
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'region=es&key=%s&address=Toledo' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'region=es&key=%s&address=Toledo' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_geocode_with_component_filter(self):
@@ -120,11 +120,11 @@ class GeocodingTest(unittest.TestCase):
         results = googlemaps.geocode(self.ctx, 'santa cruz', 
             components={'country': 'ES'})
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'key=%s&components=country%%3AES&address=santa+cruz' % 
-                          self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'key=%s&components=country%%3AES&address=santa+cruz' % 
+                         self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_geocode_with_multiple_component_filters(self):
@@ -137,11 +137,11 @@ class GeocodingTest(unittest.TestCase):
         results = googlemaps.geocode(self.ctx, 'Torun', 
             components={'administrative_area': 'TX','country': 'US'})
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'key=%s&components=administrative_area%%3ATX%%7C'
-                          'country%%3AUS&address=Torun' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'key=%s&components=administrative_area%%3ATX%%7C'
+                         'country%%3AUS&address=Torun' % self.key,
+                         responses.calls[0].request.url)
 
 
     @responses.activate
@@ -157,11 +157,11 @@ class GeocodingTest(unittest.TestCase):
                         'administrative_area': 'Helsinki', 
                         'country': 'Findland'})
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'key=%s&components=administrative_area%%3AHelsinki'
-                          '%%7Croute%%3AAnnegatan%%7Ccountry%%3AFindland' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'key=%s&components=administrative_area%%3AHelsinki'
+                         '%%7Croute%%3AAnnegatan%%7Ccountry%%3AFindland' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_simple_reverse_geocode(self):
@@ -173,10 +173,10 @@ class GeocodingTest(unittest.TestCase):
 
         results = googlemaps.reverse_geocode(self.ctx, (40.714224, -73.961452))
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'latlng=40.714224%%2C-73.961452&key=%s' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'latlng=40.714224%%2C-73.961452&key=%s' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_reverse_geocode_restricted_by_type(self):
@@ -190,11 +190,11 @@ class GeocodingTest(unittest.TestCase):
                                           location_type='ROOFTOP',
                                           result_type='street_address')
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'latlng=40.714224%%2C-73.961452&result_type=street_address&'
-                          'key=%s&location_type=ROOFTOP' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'latlng=40.714224%%2C-73.961452&result_type=street_address&'
+                         'key=%s&location_type=ROOFTOP' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_reverse_geocode_multiple_location_types(self):
@@ -209,12 +209,12 @@ class GeocodingTest(unittest.TestCase):
                                                          'RANGE_INTERPOLATED'],
                                           result_type='street_address')
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'latlng=40.714224%%2C-73.961452&result_type=street_address&'
-                          'key=%s&location_type=ROOFTOP%%7CRANGE_INTERPOLATED' % 
-                          self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'latlng=40.714224%%2C-73.961452&result_type=street_address&'
+                         'key=%s&location_type=ROOFTOP%%7CRANGE_INTERPOLATED' % 
+                         self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_reverse_geocode_multiple_result_types(self):
@@ -229,11 +229,11 @@ class GeocodingTest(unittest.TestCase):
                                           result_type=['street_address',
                                                        'route'])
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'latlng=40.714224%%2C-73.961452&result_type=street_address'
-                          '%%7Croute&key=%s&location_type=ROOFTOP' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'latlng=40.714224%%2C-73.961452&result_type=street_address'
+                         '%%7Croute&key=%s&location_type=ROOFTOP' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_partial_match(self):
@@ -245,10 +245,10 @@ class GeocodingTest(unittest.TestCase):
 
         results = googlemaps.geocode(self.ctx, 'Pirrama Pyrmont')
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'key=%s&address=Pirrama+Pyrmont' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'key=%s&address=Pirrama+Pyrmont' % self.key,
+                         responses.calls[0].request.url)
 
     @responses.activate
     def test_utf_results(self):
@@ -260,7 +260,7 @@ class GeocodingTest(unittest.TestCase):
 
         results = googlemaps.geocode(self.ctx, components={'postal_code': '96766'})
 
-        self.assertEquals(1, len(responses.calls))
-        self.assertEquals('https://maps.googleapis.com/maps/api/geocode/json?'
-                          'key=%s&components=postal_code%%3A96766' % self.key,
-                          responses.calls[0].request.url)
+        self.assertEqual(1, len(responses.calls))
+        self.assertEqual('https://maps.googleapis.com/maps/api/geocode/json?'
+                         'key=%s&components=postal_code%%3A96766' % self.key,
+                         responses.calls[0].request.url)

--- a/test/test_timezone.py
+++ b/test/test_timezone.py
@@ -33,18 +33,18 @@ class TimezoneTest(unittest.TestCase):
     def test_los_angeles(self):
         timezone = googlemaps.timezone(self.c, (39.6034810,-119.6822510), 1331766000)
         self.assertIsNotNone(timezone)
-        self.assertEquals(3600.0, timezone['dstOffset'])
-        self.assertEquals('America/Los_Angeles', timezone['timeZoneId'])
-        self.assertEquals('Pacific Daylight Time', timezone['timeZoneName'])
+        self.assertEqual(3600.0, timezone['dstOffset'])
+        self.assertEqual('America/Los_Angeles', timezone['timeZoneId'])
+        self.assertEqual('Pacific Daylight Time', timezone['timeZoneName'])
 
     def test_los_angeles_es(self):
         timezone = googlemaps.timezone(self.c, (39.6034810,-119.6822510), 1331766000, language='es')
         self.assertIsNotNone(timezone)
-        self.assertEquals(3600.0, timezone['dstOffset'])
-        self.assertEquals('America/Los_Angeles', timezone['timeZoneId'])
-        self.assertEquals(u'Hora de verano del Pacífico', timezone['timeZoneName'])
+        self.assertEqual(3600.0, timezone['dstOffset'])
+        self.assertEqual('America/Los_Angeles', timezone['timeZoneId'])
+        self.assertEqual(u'Hora de verano del Pacífico', timezone['timeZoneName'])
 
     def test_los_angeles_with_no_timestamp(self):
         timezone = googlemaps.timezone(self.c, (39.6034810,-119.6822510))
         self.assertIsNotNone(timezone)
-        self.assertEquals('America/Los_Angeles', timezone['timeZoneId'])
+        self.assertEqual('America/Los_Angeles', timezone['timeZoneId'])


### PR DESCRIPTION
Still works in Python 2.7.
