### PR TITLE
Sort parameters for enterprise signing - makes the request URLs deterministic

### DIFF
--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -185,7 +185,8 @@ class Client(object):
         if self.client_id and self.client_secret:
             params["client"] = self.client_id
 
-            path = "?".join([path, urlencode(params)])
+            # Sort params - signature changes depending on the order.
+            path = "?".join([path, urlencode(sort_params(params))])
             sig = sign_hmac(self.client_secret, path)
             return path + "&signature=" + sig
 
@@ -219,3 +220,8 @@ def sign_hmac(secret, payload):
     sig = hmac.new(base64.urlsafe_b64decode(secret), payload, hashlib.sha1)
     out = base64.urlsafe_b64encode(sig.digest())
     return out.decode('utf-8')
+
+def sort_params(params):
+    """Sorts a params dict into a list of tuples, sorted by their keys."""
+
+    return sorted(params.items(), key=lambda t: t[0])

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -78,9 +78,13 @@ class ClientTest(_test.TestCase):
         client.geocode("Sesame St.")
 
         self.assertEqual(1, len(responses.calls))
+
+        # Check ordering of parameters.
+        self.assertIn("address=Sesame+St.&client=foo&signature",
+                responses.calls[0].request.url)
         self.assertURLEqual("https://maps.googleapis.com/maps/api/geocode/json?"
-                            "client=foo&address=Sesame+St.&"
-                            "signature=Ao1r8ULP1g_vPwnf7Fvf2TSCYBQ=",
+                            "address=Sesame+St.&client=foo&"
+                            "signature=fxbWUIcNPZSekVOhp2ul9LW5TpY=",
                             responses.calls[0].request.url)
 
     @responses.activate


### PR DESCRIPTION
Tests occasionally fail without this.

@samthor @markmcd @domesticmouse PTAL
