### PR TITLE
Don't urlencode unreserved chars. Closes #72.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@ Dave Holmes <daveholmes@google.com>
 Luke Mahe <lukem@google.com>
 Mark McDonald <macd@google.com>
 Sam Thorogood <thorogood@google.com>
+Stephen McDonald <stephenmcd@google.com>

--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -278,9 +278,12 @@ def urlencode_params(params):
     :type params: list of key/value tuples.
     """
     # urlencode does not handle unicode strings in Python 2.
-    # First normalize the values so they get encoded correctly.
+    # Firstly, normalize the values so they get encoded correctly.
     params = [(key, normalize_for_urlencode(val)) for key, val in params]
-    return urlencode(params)
+    # Secondly, unquote unreserved chars which are incorrectly quoted
+    # by urllib.urlencode, causing invalid auth signatures. See GH #72
+    # for more info.
+    return requests.utils.unquote_unreserved(urlencode(params))
 
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info <= (2, 4):
 
 
 requirements = [
-    'requests',
+    'requests<=2.6',
 ]
 
 setup(name='googlemaps',

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -36,6 +36,11 @@ class ClientTest(_test.TestCase):
             client = googlemaps.Client(key="Invalid key.")
             client.directions("Sydney", "Melbourne")
 
+    def test_urlencode(self):
+        # See GH #72.
+        encoded_params = _client.urlencode_params([("address", "=Sydney ~")])
+        self.assertEqual("address=%3DSydney+~", encoded_params)
+
     @responses.activate
     def test_key_sent(self):
         responses.add(responses.GET,


### PR DESCRIPTION
Hey @markmcd I also pinned the requests version since we're using its internal API for consistency. 