### PR TITLE
Update error message in convert.components

### DIFF
--- a/googlemaps/convert.py
+++ b/googlemaps/convert.py
@@ -164,7 +164,7 @@ def components(arg):
         return "|".join(arg)
 
     raise TypeError(
-        "Expected a string or dict for components, "
+        "Expected a dict for components, "
         "but got %s" % type(arg).__name__)
 
 


### PR DESCRIPTION
The `convert.components` only accepts a dict, but in the error message said that it accepts a string too.