### PR TITLE
Add traffic_model parameter

### DIFF
--- a/googlemaps/directions.py
+++ b/googlemaps/directions.py
@@ -24,7 +24,7 @@ def directions(client, origin, destination,
                mode=None, waypoints=None, alternatives=False, avoid=None,
                language=None, units=None, region=None, departure_time=None,
                arrival_time=None, optimize_waypoints=False, transit_mode=None,
-               transit_routing_preference=None):
+               transit_routing_preference=None, traffic_model=None):
     """Get directions between an origin point and a destination point.
 
     :param origin: The address or latitude/longitude value from which you wish
@@ -82,6 +82,10 @@ def directions(client, origin, destination,
     :param transit_routing_preference: Specifies preferences for transit
         requests. Valid values are "less_walking" or "fewer_transfers"
     :type transit_routing_preference: string
+    
+    :param traffic_model: Specifies the predictive travel time model to use.
+        "best_guess" or "optimistic" or "pessimistic"
+    :type units: string
 
     :rtype: list of routes
     """
@@ -137,6 +141,9 @@ def directions(client, origin, destination,
 
     if transit_routing_preference:
         params["transit_routing_preference"] = transit_routing_preference
+        
+    if traffic_model:
+        params["traffic_model"] = traffic_model
 
     return client._get("/maps/api/directions/json", params)["routes"]
 


### PR DESCRIPTION
This new parameter allows customers with Client IDs to utilize "Predictive Time in Traffic" in Directions queries which allows them to specify a travel_model (best_guess, optimistic, pessimistic) for a Directions result set to a departure time in the future and returns an estimated durration_in_traffic based on Google's historical traffic data for that day and time.