### PR TITLE
Use utcnow to generate timestamp

### DIFF
--- a/googlemaps/timezone.py
+++ b/googlemaps/timezone.py
@@ -45,7 +45,7 @@ def timezone(client, location, timestamp=None, language=None):
 
     location = convert.latlng(location)
 
-    timestamp = convert.time(timestamp or datetime.now())
+    timestamp = convert.time(timestamp or datetime.utcnow())
 
     params = {
         "location": location,

--- a/test/test_timezone.py
+++ b/test/test_timezone.py
@@ -55,6 +55,7 @@ class TimezoneTest(_test.TestCase):
 
         def now(self):
             return datetime.datetime.fromtimestamp(1608)
+        utcnow = now
 
     @responses.activate
     @mock.patch("googlemaps.timezone.datetime", MockDatetime())


### PR DESCRIPTION
`datetime.now()` generates a localized, (naive) timestamp, but the seconds since epoch timestamp must be utc. 