### PR TITLE
Refactor duplicate convert waypoints code

### DIFF
--- a/googlemaps/convert.py
+++ b/googlemaps/convert.py
@@ -205,6 +205,66 @@ def bounds(arg):
         "Expected a bounds (southwest/northeast) dict, "
         "but got %s" % type(arg).__name__)
 
+def waypoint(arg):
+    """Converts a lat/lon pair or place to the format expected by the Google Maps
+    server.
+
+    For example:
+    p = {"lat" : -33.867486, "lng" : 151.206990}
+    convert.waypoint(p)
+    # '-33.867486,151.206990'
+    p = 'Sydney'
+    convert.waypoint(p)
+    # 'Sydney'
+
+    :param arg: The waypoint.
+    :type arg: dict or list or tuple or string
+    :rtype: basestring
+    """
+    return arg if is_string(arg) else latlng(arg)
+
+def waypoints(waypoints):
+    """Converts a lat/lon pairs or places to the format expected by the Google Maps
+    server.
+
+    For example:
+    p = [{"lat" : -33.867486, "lng" : 151.206990}, "Sydney"]
+    convert.waypoint(p)
+    # '-33.867486,151.206990|Sydney'
+
+    :param arg: The waypoint list.
+    :type arg: list
+    :rtype: basestring
+    """
+
+    # Handle the single-tuple case
+    if type(waypoints) is tuple:
+        waypoints = [waypoints]
+    else:
+        waypoints = as_list(waypoints)
+
+    return join_list("|", [waypoint(k) for k in waypoints])
+
+def locations(locations):
+    """Converts a lat/lon pairs to the format expected by the Google Maps
+    server.
+
+    For example:
+    p = [{"lat" : -33.867486, "lng" : 151.206990}, {"lat" : -33.867486, "lng" : 151.306990}]
+    convert.waypoint(p)
+    # '-33.867486,151.206990|-33.867486,151.206990'
+
+    :param arg: The location list.
+    :type arg: list
+    :rtype: basestring
+    """
+
+    # Handle the single-tuple case
+    if type(locations) is tuple:
+        locations = [locations]
+    else:
+        locations = as_list(locations)
+    return join_list("|", [latlng(k) for k in locations])
 
 def decode_polyline(polyline):
     """Decodes a Polyline string into a list of lat/lng dicts.

--- a/googlemaps/directions.py
+++ b/googlemaps/directions.py
@@ -87,8 +87,8 @@ def directions(client, origin, destination,
     """
 
     params = {
-        "origin": _convert_waypoint(origin),
-        "destination": _convert_waypoint(destination)
+        "origin": convert.waypoint(origin),
+        "destination": convert.waypoint(destination)
     }
 
     if mode:
@@ -100,7 +100,7 @@ def directions(client, origin, destination,
 
     if waypoints:
         waypoints = convert.as_list(waypoints)
-        waypoints = [_convert_waypoint(waypoint) for waypoint in waypoints]
+        waypoints = [convert.waypoint(waypoint) for waypoint in waypoints]
 
         if optimize_waypoints:
             waypoints = ["optimize:true"] + waypoints
@@ -139,9 +139,3 @@ def directions(client, origin, destination,
         params["transit_routing_preference"] = transit_routing_preference
 
     return client._get("/maps/api/directions/json", params)["routes"]
-
-def _convert_waypoint(waypoint):
-    if not convert.is_string(waypoint):
-        return convert.latlng(waypoint)
-
-    return waypoint

--- a/googlemaps/distance_matrix.py
+++ b/googlemaps/distance_matrix.py
@@ -77,8 +77,8 @@ def distance_matrix(client, origins, destinations,
     """
 
     params = {
-        "origins": _convert_path(origins),
-        "destinations": _convert_path(destinations)
+        "origins": convert.waypoints(origins),
+        "destinations": convert.waypoints(destinations)
     }
 
     if mode:
@@ -116,15 +116,3 @@ def distance_matrix(client, origins, destinations,
         params["transit_routing_preference"] = transit_routing_preference
 
     return client._get("/maps/api/distancematrix/json", params)
-
-
-def _convert_path(waypoints):
-    # Handle the single-tuple case
-    if type(waypoints) is tuple:
-        waypoints = [waypoints]
-    else:
-        waypoints = as_list(waypoints)
-
-    return convert.join_list("|",
-            [(k if convert.is_string(k) else convert.latlng(k))
-                for k in waypoints])

--- a/googlemaps/elevation.py
+++ b/googlemaps/elevation.py
@@ -31,12 +31,9 @@ def elevation(client, locations):
 
     :rtype: list of elevation data responses
     """
-    params = {}
-    if type(locations) is tuple:
-        locations = [locations]
-
-    params["locations"] = convert.join_list("|",
-            [convert.latlng(k) for k in convert.as_list(locations)])
+    params = {
+        "locations": convert.locations(locations)
+    }
 
     return client._get("/maps/api/elevation/json", params)["results"]
 
@@ -59,8 +56,7 @@ def elevation_along_path(client, path, samples):
     if type(path) is str:
         path = "enc:%s" % path
     else:
-        path = convert.join_list("|",
-                [convert.latlng(k) for k in convert.as_list(path)])
+        path = convert.locations(path)
 
     params = {
         "path": path,

--- a/googlemaps/roads.py
+++ b/googlemaps/roads.py
@@ -43,14 +43,8 @@ def snap_to_roads(client, path, interpolate=False):
     :rtype: A list of snapped points.
     """
 
-    if type(path) is tuple:
-        path = [path]
-
-    path = convert.join_list("|",
-            [convert.latlng(k) for k in convert.as_list(path)])
-
     params = {
-        "path": path
+        "path": convert.locations(path)
     }
 
     if interpolate:
@@ -94,14 +88,8 @@ def snapped_speed_limits(client, path):
             points.
     """
 
-    if type(path) is tuple:
-        path = [path]
-
-    path = convert.join_list("|",
-            [convert.latlng(k) for k in convert.as_list(path)])
-
     params = {
-        "path": path
+        "path": convert.locations(path)
     }
 
     return client._get("/v1/speedLimits", params,

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -94,6 +94,24 @@ class ConvertTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             convert.bounds("test")
 
+    def test_waypoint(self):
+        p = {"lat": 3, "lng": 4}
+        self.assertEqual("3.000000,4.000000",
+                          convert.waypoint(p))
+        p = "Sydney"
+        self.assertEqual("Sydney",
+                          convert.waypoint(p))
+
+    def test_waypoints(self):
+        p = [{"lat": 3, "lng": 4}, "Sydney"]
+        self.assertEqual("3.000000,4.000000|Sydney",
+                          convert.waypoints(p))
+
+    def test_locations(self):
+        p = [(1, 2), {"lat": 3, "lng": 4}]
+        self.assertEqual("1.000000,2.000000|3.000000,4.000000",
+                          convert.waypoints(p))
+
     def test_polyline_decode(self):
         syd_mel_route = ("rvumEis{y[`NsfA~tAbF`bEj^h{@{KlfA~eA~`AbmEghAt~D|e@j"
                          "lRpO~yH_\\v}LjbBh~FdvCxu@`nCplDbcBf_B|wBhIfhCnqEb~D~"


### PR DESCRIPTION
There are some duplicate code to convert waypoint/location across some APIs. I moved all waypoint/location converter into `convert.py`.