### PR TITLE
Use container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python: 2.7
 
+# Use container-based infrastructure
+sudo: false
+
 install:
   - pip install requests
   - pip install tox


### PR DESCRIPTION

Travis CI docs say:
> Jobs running on container-based infrastructure:
> 1. start up faster
> 2. allow the use of caches for public repositories
> 3. disallow the use of sudo, setuid and setgid executables

https://docs.travis-ci.com/user/workers/container-based-infrastructure/