### PR TITLE
Support reverse_geocode by place_id

### DIFF
--- a/googlemaps/geocoding.py
+++ b/googlemaps/geocoding.py
@@ -90,7 +90,9 @@ def reverse_geocode(client, latlng, result_type=None, location_type=None,
     :rtype: list of reverse geocoding results.
     """
 
-    if (convert.is_string(latlng) and (',' not in latlng)):
+    # Check if latlng param is a place_id string.
+    #  place_id strings do not contain commas; latlng strings do.
+    if convert.is_string(latlng) and ',' not in latlng:
         params = {"place_id": latlng}
     else:
         params = {"latlng": convert.latlng(latlng)}

--- a/googlemaps/geocoding.py
+++ b/googlemaps/geocoding.py
@@ -90,7 +90,7 @@ def reverse_geocode(client, latlng, result_type=None, location_type=None,
     :rtype: list of reverse geocoding results.
     """
 
-    if (type(latlng) == str) & (latlng[0] not in ("-+0123456789")):
+    if (convert.is_string(latlng) and (',' not in latlng)):
         params = {"place_id": latlng}
     else:
         params = {"latlng": convert.latlng(latlng)}

--- a/googlemaps/geocoding.py
+++ b/googlemaps/geocoding.py
@@ -68,8 +68,8 @@ def geocode(client, address=None, components=None, bounds=None, region=None,
     return client._get("/maps/api/geocode/json", params)["results"]
 
 
-def reverse_geocode(client, latlng, result_type=None, location_type=None,
-                    language=None):
+def reverse_geocode(client, latlng, result_type=None,
+                    location_type=None, language=None):
     """
     Reverse geocoding is the process of converting geographic coordinates into a
     human-readable address.
@@ -77,6 +77,10 @@ def reverse_geocode(client, latlng, result_type=None, location_type=None,
     :param latlng: The latitude/longitude value for which you wish to obtain the
         closest, human-readable address.
     :type latlng: string, dict, list, or tuple
+    
+    :param place_id: The place_id for which you wish to obtain the
+        closest, human-readable address.
+    :type place_id: string
 
     :param result_type: One or more address types to restrict results to.
     :type result_type: string or list of strings
@@ -90,7 +94,10 @@ def reverse_geocode(client, latlng, result_type=None, location_type=None,
     :rtype: list of reverse geocoding results.
     """
 
-    params = {"latlng": convert.latlng(latlng)}
+    if (type(latlng) == str) & (latlng[0] in ("-0123456789")):
+    	params = {"place_id": latlng}
+    else:
+	    params = {"latlng": convert.latlng(latlng)}
 
     if result_type:
         params["result_type"] = convert.join_list("|", result_type)

--- a/googlemaps/geocoding.py
+++ b/googlemaps/geocoding.py
@@ -68,20 +68,16 @@ def geocode(client, address=None, components=None, bounds=None, region=None,
     return client._get("/maps/api/geocode/json", params)["results"]
 
 
-def reverse_geocode(client, latlng, result_type=None,
-                    location_type=None, language=None):
+def reverse_geocode(client, latlng, result_type=None, location_type=None,
+                    language=None):
     """
     Reverse geocoding is the process of converting geographic coordinates into a
     human-readable address.
 
-    :param latlng: The latitude/longitude value for which you wish to obtain the
-        closest, human-readable address.
+    :param latlng: The latitude/longitude value or place_id for which you wish
+        to obtain the closest, human-readable address.
     :type latlng: string, dict, list, or tuple
     
-    :param place_id: The place_id for which you wish to obtain the
-        closest, human-readable address.
-    :type place_id: string
-
     :param result_type: One or more address types to restrict results to.
     :type result_type: string or list of strings
 
@@ -94,10 +90,10 @@ def reverse_geocode(client, latlng, result_type=None,
     :rtype: list of reverse geocoding results.
     """
 
-    if (type(latlng) == str) & (latlng[0] in ("-0123456789")):
-    	params = {"place_id": latlng}
+    if (type(latlng) in (str, unicode)) & (latlng[0] not in ("-+0123456789")):
+        params = {"place_id": latlng}
     else:
-	    params = {"latlng": convert.latlng(latlng)}
+        params = {"latlng": convert.latlng(latlng)}
 
     if result_type:
         params["result_type"] = convert.join_list("|", result_type)

--- a/googlemaps/geocoding.py
+++ b/googlemaps/geocoding.py
@@ -90,7 +90,7 @@ def reverse_geocode(client, latlng, result_type=None, location_type=None,
     :rtype: list of reverse geocoding results.
     """
 
-    if (type(latlng) in (str, unicode)) & (latlng[0] not in ("-+0123456789")):
+    if (type(latlng) == str) & (latlng[0] not in ("-+0123456789")):
         params = {"place_id": latlng}
     else:
         params = {"latlng": convert.latlng(latlng)}


### PR DESCRIPTION
Add support for reverse geocoding by place_id in addition to existing lat/lng. Doesn't change interface, just checks for a string that begins with something other than a digit or a +/- sign. Treats such strings as place_ids, otherwise behaves like current code.