### PR TITLE
Shorter urls

### DIFF
--- a/googlemaps/convert.py
+++ b/googlemaps/convert.py
@@ -31,6 +31,29 @@
 import time as _time
 
 
+def format_float(arg):
+    """Formats a float value to be as short as possible.
+
+    Trims extraneous trailing zeros and period to give API
+    args the best possible chance of fitting within 2000 char
+    URL length restrictions.
+
+    For example:
+
+    format_float(40) -> "40"
+    format_float(40.0) -> "40"
+    format_float(40.1) -> "40.1"
+    format_float(40.001) -> "40.001"
+    format_float(40.0010) -> "40.001"
+
+    :param arg: The lat or lng float.
+    :type arg: float
+
+    :rtype: string
+    """
+    return ("%f" % float(arg)).rstrip("0").rstrip(".")
+
+
 def latlng(arg):
     """Converts a lat/lon pair to a comma-separated string.
 
@@ -50,7 +73,11 @@ def latlng(arg):
     :param arg: The lat/lon pair.
     :type arg: string or dict or list or tuple
     """
-    return arg if is_string(arg) else "%f,%f" % normalize_lat_lng(arg)
+    if is_string(arg):
+        return arg
+
+    normalized = normalize_lat_lng(arg)
+    return "%s,%s" % (format_float(normalized[0]), format_float(normalized[1]))
 
 
 def normalize_lat_lng(arg):

--- a/googlemaps/convert.py
+++ b/googlemaps/convert.py
@@ -314,3 +314,26 @@ def encode_polyline(points):
         last_lng = lng
 
     return result
+
+
+def shortest_path(locations):
+    """Returns the shortest representation of the given locations.
+
+    The Elevations API limits requests to 2000 characters, and accepts
+    multiple locations either as pipe-delimited lat/lng values, or
+    an encoded polyline, so we determine which is shortest and use it.
+
+    :param locations: The lat/lng list.
+    :type locations: list
+
+    :rtype: string
+    """
+    if isinstance(locations, tuple):
+        # Handle the single-tuple lat/lng case.
+        locations = [locations]
+    encoded = "enc:%s" % encode_polyline(locations)
+    unencoded = location_list(locations)
+    if len(encoded) < len(unencoded):
+        return encoded
+    else:
+        return unencoded

--- a/googlemaps/elevation.py
+++ b/googlemaps/elevation.py
@@ -33,7 +33,7 @@ def elevation(client, locations):
 
     :rtype: list of elevation data responses
     """
-    params = {"locations": convert.location_list(locations)}
+    params = {"locations": convert.shortest_path(locations)}
     return client._get("/maps/api/elevation/json", params)["results"]
 
 
@@ -55,7 +55,7 @@ def elevation_along_path(client, path, samples):
     if type(path) is str:
         path = "enc:%s" % path
     else:
-        path = convert.location_list(path)
+        path = convert.shortest_path(path)
 
     params = {
         "path": path,

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -26,7 +26,7 @@ from googlemaps import convert
 class ConvertTest(unittest.TestCase):
 
     def test_latlng(self):
-        expected = "1.000000,2.000000"
+        expected = "1,2"
         ll = {"lat": 1, "lng": 2}
         self.assertEqual(expected, convert.latlng(ll))
 
@@ -42,7 +42,7 @@ class ConvertTest(unittest.TestCase):
             convert.latlng(1)
 
     def test_location_list(self):
-        expected = "1.000000,2.000000|1.000000,2.000000"
+        expected = "1,2|1,2"
         ll = [{"lat": 1, "lng": 2}, {"lat": 1, "lng": 2}]
         self.assertEqual(expected, convert.location_list(ll))
 
@@ -104,7 +104,7 @@ class ConvertTest(unittest.TestCase):
         ne = {"lat": 1, "lng": 2}
         sw = (3, 4)
         b = {"northeast": ne, "southwest": sw}
-        self.assertEqual("3.000000,4.000000|1.000000,2.000000",
+        self.assertEqual("3,4|1,2",
                           convert.bounds(b))
 
         with self.assertRaises(TypeError):

--- a/test/test_distance_matrix.py
+++ b/test/test_distance_matrix.py
@@ -77,7 +77,7 @@ class DistanceMatrixTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual('https://maps.googleapis.com/maps/api/distancematrix/json?'
-                            'key=%s&origins=Bobcaygeon+ON%%7C41.432060%%2C-81.389920&'
+                            'key=%s&origins=Bobcaygeon+ON%%7C41.43206%%2C-81.38992&'
                             'destinations=43.012486%%2C-83.696415%%7C42.886386%%2C'
                             '-78.878163' % self.key,
                             responses.calls[0].request.url)

--- a/test/test_elevation.py
+++ b/test/test_elevation.py
@@ -97,3 +97,18 @@ class ElevationTest(_test.TestCase):
                             'path=enc:abowFtzsbMhgmiMuobzi@&'
                             'key=%s&samples=5' % self.key,
                             responses.calls[0].request.url)
+
+    @responses.activate
+    def test_short_latlng(self):
+        responses.add(responses.GET,
+                      'https://maps.googleapis.com/maps/api/elevation/json',
+                      body='{"status":"OK","results":[]}',
+                      status=200,
+                      content_type='application/json')
+
+        results = self.client.elevation((40, -73))
+
+        self.assertEqual(1, len(responses.calls))
+        self.assertURLEqual('https://maps.googleapis.com/maps/api/elevation/json?'
+                            'locations=40,-73&key=%s' % self.key,
+                            responses.calls[0].request.url)

--- a/test/test_elevation.py
+++ b/test/test_elevation.py
@@ -41,7 +41,7 @@ class ElevationTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual('https://maps.googleapis.com/maps/api/elevation/json?'
-                            'locations=40.714728%%2C-73.998672&key=%s' % self.key,
+                            'locations=enc:abowFtzsbM&key=%s' % self.key,
                             responses.calls[0].request.url)
 
     @responses.activate
@@ -56,7 +56,7 @@ class ElevationTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual('https://maps.googleapis.com/maps/api/elevation/json?'
-                            'locations=40.714728%%2C-73.998672&key=%s' % self.key,
+                            'locations=enc:abowFtzsbM&key=%s' % self.key,
                             responses.calls[0].request.url)
 
     @responses.activate
@@ -72,8 +72,7 @@ class ElevationTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual('https://maps.googleapis.com/maps/api/elevation/json?'
-                            'locations=40.714728%%2C-73.998672%%7C-34.397000%%2C'
-                            '150.644000&key=%s' % self.key,
+                            'locations=enc:abowFtzsbMhgmiMuobzi@&key=%s' % self.key,
                             responses.calls[0].request.url)
 
     def test_elevation_along_path_single(self):
@@ -95,7 +94,6 @@ class ElevationTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual('https://maps.googleapis.com/maps/api/elevation/json?'
-                            'path=40.714728%%2C-73.998672%%7C-34.397000%%2C150.644000&'
+                            'path=enc:abowFtzsbMhgmiMuobzi@&'
                             'key=%s&samples=5' % self.key,
                             responses.calls[0].request.url)
-

--- a/test/test_geocoding.py
+++ b/test/test_geocoding.py
@@ -57,7 +57,7 @@ class GeocodingTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual('https://maps.googleapis.com/maps/api/geocode/json?'
-                            'latlng=-33.867487%%2C151.206990&key=%s' % self.key,
+                            'latlng=-33.867487%%2C151.20699&key=%s' % self.key,
                             responses.calls[0].request.url)
 
     @responses.activate

--- a/test/test_places.py
+++ b/test/test_places.py
@@ -48,7 +48,7 @@ class PlacesTest(_test.TestCase):
                            min_price=1, max_price=4, open_now=True)
 
         self.assertEqual(1, len(responses.calls))
-        self.assertURLEqual('%s?language=en-AU&location=-33.867460%%2C151.207090&'
+        self.assertURLEqual('%s?language=en-AU&location=-33.86746%%2C151.20709&'
                             'maxprice=4&minprice=1&opennow=true&query=restaurant&'
                             'radius=100&key=%s'
                             % (url, self.key), responses.calls[0].request.url)

--- a/test/test_roads.py
+++ b/test/test_roads.py
@@ -58,7 +58,7 @@ class RoadsTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual("https://roads.googleapis.com/v1/speedLimits?"
-                            "path=1.000000%%2C2.000000|3.000000%%2C4.000000"
+                            "path=1%%2C2|3%%2C4"
                             "&key=%s" % self.key,
                             responses.calls[0].request.url)
 


### PR DESCRIPTION
Two changes here to help address #113 

1) As per Java lib, use polyline encoding of multiple latlngs if it results in a shorter value in elevation API
2) As discussed, improved formatting for latlngs to remove extraneous zeros and periods

PTAL @domesticmouse @markmcd 