### PR TITLE
Bump requests dependency to stay under next major

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info <= (2, 4):
 
 
 requirements = [
-    'requests<=2.9.1',
+    'requests<3',
 ]
 
 setup(name='googlemaps',


### PR DESCRIPTION
For some reason the `requests` dependency in py-googlemaps was restricted to some old version of requests.

Usually what's specified is more in the form of : `requests>=1.x`. Anyway, since I guess it's mostly backwards-compatible, let's pin it to stay under the next major and that's it.