### PR TITLE
Fix: channel argument should always be allowed when there is a client_id

### DIFF
--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -114,7 +114,7 @@ class Client(object):
         if channel:
             if not client_id:
                 raise ValueError("The channel argument must be used with a "
-                             "client ID")
+                                 "client ID")
             if not re.match("^[a-zA-Z0-9._-]*$", channel):
                 raise ValueError("The channel argument must be an ASCII "
                     "alphanumeric string. The period (.), underscore (_)"

--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -66,7 +66,7 @@ class Client(object):
         :param channel: (for Maps API for Work customers) When set, a channel
             parameter with this value will be added to the requests.
             This can be used for tracking purpose.
-            Can not be used with a Maps API key.
+            Can only be used with a Maps API client ID.
         :type channel: str
 
         :param timeout: Combined connect and read timeout for HTTP requests, in
@@ -112,9 +112,9 @@ class Client(object):
             raise ValueError("Invalid API key provided.")
 
         if channel:
-            if key:
-                raise ValueError("The channel argument can not be used with an "
-                             "API key")
+            if not client_id:
+                raise ValueError("The channel argument must be used with a "
+                             "client ID")
             if not re.match("^[a-zA-Z0-9._-]*$", channel):
                 raise ValueError("The channel argument must be an ASCII "
                     "alphanumeric string. The period (.), underscore (_)"

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -217,13 +217,14 @@ class ClientTest(_test.TestCase):
 
         self.assertEqual(2, len(responses.calls))
 
-    def test_channel_with_api_key(self):
+    def test_channel_without_client_id(self):
         with self.assertRaises(ValueError):
             client = googlemaps.Client(key="AIzaasdf", channel="mychannel")
 
     def test_invalid_channel(self):
         with self.assertRaises(ValueError):
-            client = googlemaps.Client(client_id="foo", client_secret="a2V5", channel="auieauie$? ")
+            client = googlemaps.Client(client_id="foo", client_secret="a2V5", 
+                                       channel="auieauie$? ")
 
     @responses.activate
     def test_channel_with_client_id(self):
@@ -233,7 +234,8 @@ class ClientTest(_test.TestCase):
                       status=200,
                       content_type="application/json")
 
-        client = googlemaps.Client(client_id="foo", client_secret="a2V5", channel="MyChannel_1")
+        client = googlemaps.Client(key="AIzaasdf", client_id="foo", client_secret="a2V5", 
+                                   channel="MyChannel_1")
         client.geocode("Sesame St.")
 
         self.assertEqual(1, len(responses.calls))


### PR DESCRIPTION
googlemaps.Client: the 'channel' argument can now be given whenever there is a client_id (instead of only when there is no API key).