### PR TITLE
Fixed bug where requests version was incorrectly interpreted.

### DIFF
--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -129,7 +129,7 @@ class Client(object):
         if connect_timeout and read_timeout:
             # Check that the version of requests is >= 2.4.0
             chunks = requests.__version__.split(".")
-            if chunks[0] < 2 or (chunks[0] == 2 and chunks[1] < 4):
+            if int(chunks[0]) < 2 or (int(chunks[0]) == 2 and int(chunks[1]) < 4):
                 raise NotImplementedError("Connect/Read timeouts require "
                                           "requests v2.4.0 or higher")
             self.timeout = (connect_timeout, read_timeout)


### PR DESCRIPTION
Bug fixed on Python 3 causing a TypeError when checking the requests version making it unable of passing `connect_timeout` and `read_timeout` to the client . Added a test for the future.