### PR TITLE
Allow a requests.Session object to be passed into Client

### DIFF
--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -51,7 +51,7 @@ class Client(object):
     def __init__(self, key=None, client_id=None, client_secret=None,
                  timeout=None, connect_timeout=None, read_timeout=None,
                  retry_timeout=60, requests_kwargs=None,
-                 queries_per_second=10, channel=None, requests_session=None):
+                 queries_per_second=10, channel=None):
         """
         :param key: Maps API key. Required, unless "client_id" and
             "client_secret" are set.
@@ -104,9 +104,6 @@ class Client(object):
             http://docs.python-requests.org/en/latest/api/#main-interface
         :type requests_kwargs: dict
 
-        :param requests_session: Re-usable requests.session object for re-using connections
-        :type requests_session: request.Session
-
         """
         if not key and not (client_secret and client_id):
             raise ValueError("Must provide API key or enterprise credentials "
@@ -114,11 +111,6 @@ class Client(object):
 
         if key and not key.startswith("AIza"):
             raise ValueError("Invalid API key provided.")
-
-        if requests_session is None:
-            self.session = requests.Session()
-        else:
-            self.session = requests_session
 
         if channel:
             if not client_id:
@@ -129,6 +121,7 @@ class Client(object):
                     "alphanumeric string. The period (.), underscore (_)"
                     "and hyphen (-) characters are allowed.")
 
+        self.session = requests.Session()
         self.key = key
 
         if timeout and (connect_timeout or read_timeout):

--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -47,7 +47,6 @@ _RETRIABLE_STATUSES = set([500, 503, 504])
 
 class Client(object):
     """Performs requests to the Google Maps API web services."""
-    session = requests.Session()
 
     def __init__(self, key=None, client_id=None, client_secret=None,
                  timeout=None, connect_timeout=None, read_timeout=None,
@@ -116,7 +115,9 @@ class Client(object):
         if key and not key.startswith("AIza"):
             raise ValueError("Invalid API key provided.")
 
-        if requests_session is not None:
+        if requests_session is None:
+            self.session = requests.Session()
+        else:
             self.session = requests_session
 
         if channel:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -44,6 +44,20 @@ class ClientTest(_test.TestCase):
         self.assertEqual("address=%3DSydney+~", encoded_params)
 
     @responses.activate
+    def test_query_with_session(self):
+        session = requests.Session()
+        responses.add(responses.GET,
+                      "https://maps.googleapis.com/maps/api/geocode/json",
+                      body='{"status":"OK","results":[]}',
+                      status=200,
+                      content_type="application/json")
+        client = googlemaps.Client(key="AIzaasdf",
+                                   queries_per_second=3,
+                                   requests_session=session)
+        client.geocode("Sesame St.")
+
+
+    @responses.activate
     def test_queries_per_second(self):
         # This test assumes that the time to run a mocked query is
         # relatively small, eg a few milliseconds. We define a rate of

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -52,8 +52,8 @@ class ClientTest(_test.TestCase):
                       status=200,
                       content_type="application/json")
         client = googlemaps.Client(key="AIzaasdf",
-                                   queries_per_second=3,
-                                   requests_session=session)
+                                   queries_per_second=3)
+        client.session = session
         client.geocode("Sesame St.")
 
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -44,20 +44,6 @@ class ClientTest(_test.TestCase):
         self.assertEqual("address=%3DSydney+~", encoded_params)
 
     @responses.activate
-    def test_query_with_session(self):
-        session = requests.Session()
-        responses.add(responses.GET,
-                      "https://maps.googleapis.com/maps/api/geocode/json",
-                      body='{"status":"OK","results":[]}',
-                      status=200,
-                      content_type="application/json")
-        client = googlemaps.Client(key="AIzaasdf",
-                                   queries_per_second=3)
-        client.session = session
-        client.geocode("Sesame St.")
-
-
-    @responses.activate
     def test_queries_per_second(self):
         # This test assumes that the time to run a mocked query is
         # relatively small, eg a few milliseconds. We define a rate of


### PR DESCRIPTION
This will allow the client to re-use an existing session and not have re-establish the connection over subsequent calls.