### PR TITLE
Remove version limitation on requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info <= (2, 4):
 
 
 requirements = [
-    'requests<=2.11.1',
+    'requests',
 ]
 
 setup(name='googlemaps',


### PR DESCRIPTION
There is no documentation that this version requirement is needed anywhere, it looks like it was
added as a lark when requests 2 support was added.