### PR TITLE
Relax requirements to allow requests >=2.11 and <3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info <= (2, 4):
 
 
 requirements = [
-    'requests<=2.11.1',
+    'requests>=2.11.1,<3.0',
 ]
 
 setup(name='googlemaps',


### PR DESCRIPTION
Requests 2.x will remain API compliant, while still allowing for fixes in versions of
requests that are newer than 2.11.1. Tested with 2.13 and 2.14, works fine.