### PR TITLE
Convert datetime objects to UTC timestamps

### DIFF
--- a/googlemaps/convert.py
+++ b/googlemaps/convert.py
@@ -184,8 +184,8 @@ def time(arg):
     :type arg: datetime.datetime or int
     """
     # handle datetime instances.
-    if _has_method(arg, "timetuple"):
-        arg = _time.mktime(arg.timetuple())
+    if _has_method(arg, "timestamp"):
+        arg = arg.timestamp()
 
     if isinstance(arg, float):
         arg = int(arg)

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -84,6 +84,10 @@ class ConvertTest(unittest.TestCase):
         dt = datetime.datetime.fromtimestamp(1409810596)
         self.assertEqual("1409810596", convert.time(dt))
 
+        tz = datetime.timezone(datetime.timedelta(hours=1))
+        dt = datetime.datetime.fromtimestamp(1409810596, tz=tz)
+        self.assertEqual(str(1409810596), convert.time(dt))
+
     def test_components(self):
         c = {"country": "US"}
         self.assertEqual("country:US", convert.components(c))


### PR DESCRIPTION
The API assumes all timestamps are in UTC but we convert them to timestamps
in local time. This breaks when datetime objects are timezone-aware: we base
the timestamps on local datetime.

This commit solves this problem by using the timezone-aware .timestamp()
rather than .timetuple().

closes #186 