### PR TITLE
Set base_url default value inside _request() instead of in signature

### DIFF
--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -153,7 +153,7 @@ class Client(object):
         self.sent_times = collections.deque("", queries_per_second)
 
     def _request(self, url, params, first_request_time=None, retry_counter=0,
-             base_url=_DEFAULT_BASE_URL, accepts_clientid=True,
+             base_url=None, accepts_clientid=True,
              extract_body=None, requests_kwargs=None, post_json=None):
         """Performs HTTP GET/POST with credentials, returning the body as
         JSON.
@@ -197,6 +197,9 @@ class Client(object):
 
         if not first_request_time:
             first_request_time = datetime.now()
+
+        if not base_url:
+            base_url = _DEFAULT_BASE_URL
 
         elapsed = datetime.now() - first_request_time
         if elapsed > self.retry_timeout:


### PR DESCRIPTION
If an end-user of the library wants to override _DEFAULT_BASE_URL (e.g. in order to use a proxy), this makes it easier. The user can simply run

```
googlemaps.client._DEFAULT_BASE_URL = 'http://my_proxy_dns'
```

in their server/script's startup code.

Without this change, the default value for the parameter gets "baked" into the function definition and is harder to change.

(Obviously a module's internal implementation details are subject to change, and this PR doesn't construe a guarantee that overriding _DEFAULT_BASE_URL will continue to work in the future).