### PR TITLE
Add option to not retry when over query limit

### DIFF
--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -51,7 +51,8 @@ class Client(object):
     def __init__(self, key=None, client_id=None, client_secret=None,
                  timeout=None, connect_timeout=None, read_timeout=None,
                  retry_timeout=60, requests_kwargs=None,
-                 queries_per_second=10, channel=None):
+                 queries_per_second=10, channel=None,
+                 retry_over_query_limit=True):
         """
         :param key: Maps API key. Required, unless "client_id" and
             "client_secret" are set.
@@ -92,6 +93,11 @@ class Client(object):
             If the rate limit is reached, the client will sleep for the
             appropriate amount of time before it runs the current query.
         :type queries_per_second: int
+
+        :param retry_over_query_limit: If True, requests that result in a
+            response indicating the query rate limit was exceeded will be
+            retried. Defaults to True.
+        :type retry_over_query_limit: bool
 
         :raises ValueError: when either credentials are missing, incomplete
             or invalid.
@@ -150,6 +156,7 @@ class Client(object):
         })
 
         self.queries_per_second = queries_per_second
+        self.retry_over_query_limit = retry_over_query_limit
         self.sent_times = collections.deque("", queries_per_second)
 
     def _request(self, url, params, first_request_time=None, retry_counter=0,
@@ -253,7 +260,10 @@ class Client(object):
                 result = self._get_body(response)
             self.sent_times.append(time.time())
             return result
-        except googlemaps.exceptions._RetriableRequest:
+        except googlemaps.exceptions._RetriableRequest as e:
+            if isinstance(e, googlemaps.exceptions._OverQueryLimit) and not self.retry_over_query_limit:
+                raise
+
             # Retry request.
             return self._request(url, params, first_request_time,
                                  retry_counter + 1, base_url, accepts_clientid,
@@ -273,7 +283,7 @@ class Client(object):
             return body
 
         if api_status == "OVER_QUERY_LIMIT":
-            raise googlemaps.exceptions._RetriableRequest()
+            raise googlemaps.exceptions._OverQueryLimit()
 
         if "error_message" in body:
             raise googlemaps.exceptions.ApiError(api_status,

--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -283,13 +283,11 @@ class Client(object):
             return body
 
         if api_status == "OVER_QUERY_LIMIT":
-            raise googlemaps.exceptions._OverQueryLimit()
+            raise googlemaps.exceptions._OverQueryLimit(
+                api_status, body.get("error_message"))
 
-        if "error_message" in body:
-            raise googlemaps.exceptions.ApiError(api_status,
-                    body["error_message"])
-        else:
-            raise googlemaps.exceptions.ApiError(api_status)
+        raise googlemaps.exceptions.ApiError(api_status,
+                                             body.get("error_message"))
 
     def _generate_auth_url(self, path, params, accepts_clientid):
         """Returns the path and query string portion of the request URL, first

--- a/googlemaps/exceptions.py
+++ b/googlemaps/exceptions.py
@@ -58,3 +58,11 @@ class Timeout(Exception):
 class _RetriableRequest(Exception):
     """Signifies that the request can be retried."""
     pass
+
+class _OverQueryLimit(_RetriableRequest):
+    """Signifies that the request failed because the client exceeded its query rate limit.
+
+    Normally we treat this as a retriable condition, but we allow the calling code to specify that these requests should
+    not be retried.
+    """
+    pass

--- a/googlemaps/exceptions.py
+++ b/googlemaps/exceptions.py
@@ -59,7 +59,7 @@ class _RetriableRequest(Exception):
     """Signifies that the request can be retried."""
     pass
 
-class _OverQueryLimit(_RetriableRequest):
+class _OverQueryLimit(ApiError, _RetriableRequest):
     """Signifies that the request failed because the client exceeded its query rate limit.
 
     Normally we treat this as a retriable condition, but we allow the calling code to specify that these requests should

--- a/googlemaps/geolocation.py
+++ b/googlemaps/geolocation.py
@@ -31,7 +31,7 @@ def _geolocation_extract(response):
     if response.status_code in (200, 404):
         return body
     elif response.status_code == 403:
-        raise exceptions._RetriableRequest()
+        raise exceptions._OverQueryLimit()
     else:
         try:
             error = body["error"]["errors"][0]["reason"]

--- a/googlemaps/geolocation.py
+++ b/googlemaps/geolocation.py
@@ -30,13 +30,15 @@ def _geolocation_extract(response):
     body = response.json()
     if response.status_code in (200, 404):
         return body
-    elif response.status_code == 403:
-        raise exceptions._OverQueryLimit()
+
+    try:
+        error = body["error"]["errors"][0]["reason"]
+    except KeyError:
+        error = None
+
+    if response.status_code == 403:
+        raise exceptions._OverQueryLimit(response.status_code, error)
     else:
-        try:
-            error = body["error"]["errors"][0]["reason"]
-        except KeyError:
-            error = None
         raise exceptions.ApiError(response.status_code, error)
 
 

--- a/googlemaps/roads.py
+++ b/googlemaps/roads.py
@@ -133,12 +133,10 @@ def _roads_extract(resp):
         status = error["status"]
 
         if status == "RESOURCE_EXHAUSTED":
-            raise googlemaps.exceptions._OverQueryLimit()
+            raise googlemaps.exceptions._OverQueryLimit(status,
+                                                        error.get("message"))
 
-        if "message" in error:
-            raise googlemaps.exceptions.ApiError(status, error["message"])
-        else:
-            raise googlemaps.exceptions.ApiError(status)
+        raise googlemaps.exceptions.ApiError(status, error.get("message"))
 
     if resp.status_code != 200:
         raise googlemaps.exceptions.HTTPError(resp.status_code)

--- a/googlemaps/roads.py
+++ b/googlemaps/roads.py
@@ -133,7 +133,7 @@ def _roads_extract(resp):
         status = error["status"]
 
         if status == "RESOURCE_EXHAUSTED":
-            raise googlemaps.exceptions._RetriableRequest()
+            raise googlemaps.exceptions._OverQueryLimit()
 
         if "message" in error:
             raise googlemaps.exceptions.ApiError(status, error["message"])

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -288,3 +288,19 @@ class ClientTest(_test.TestCase):
         requests.__version__ = '2.4.0'
         googlemaps.Client(**client_args_timeout)
         googlemaps.Client(**client_args)
+
+    @responses.activate
+    def test_no_retry_over_query_limit(self):
+        responses.add(responses.GET,
+                      "https://maps.googleapis.com/foo",
+                      body='{"status":"OVER_QUERY_LIMIT"}',
+                      status=200,
+                      content_type="application/json")
+
+        client = googlemaps.Client(key="AIzaasdf",
+                                   retry_over_query_limit=False)
+
+        with self.assertRaises(googlemaps.exceptions.ApiError):
+            client._request("/foo", {})
+
+        self.assertEqual(1, len(responses.calls))


### PR DESCRIPTION
Fixes https://github.com/googlemaps/google-maps-services-python/issues/109.

Add a flag `retry_over_query_limit` to `Client.__init__` which, when set to false, will fast-fail out-of-quota errors back to the caller instead of retrying.

When the query rate limit is exceeded for a given Google Maps Service, ordinarily the client will retry the request in an endless loop. These retries eat up resources and cause the incoming request to hang. Instead we should have an option to fast-fail requests so that the calling code can decide what to do.