### PR TITLE
Broken test link

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ directions_result = gmaps.directions("Sydney Town Hall",
                                      departure_time=now)
 ```
 
-For more usage examples, check out [the tests](test/).
+For more usage examples, check out [the tests](googlemaps/test/).
 
 ## Features
 


### PR DESCRIPTION
After moving the directory containing tests inside package, link in README is broken.

Link now points one directory down, to googlemaps/test.