### PR TITLE
Do not override headers passed in request_kwargs

### DIFF
--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -149,8 +149,10 @@ class Client(object):
         self.channel = channel
         self.retry_timeout = timedelta(seconds=retry_timeout)
         self.requests_kwargs = requests_kwargs or {}
+        headers = self.request_kwargs.pop('headers', {})
+        headers.update({"User-Agent": _USER_AGENT})        
         self.requests_kwargs.update({
-            "headers": {"User-Agent": _USER_AGENT},
+            "headers": headers,
             "timeout": self.timeout,
             "verify": True,  # NOTE(cbro): verify SSL certs.
         })

--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -149,7 +149,7 @@ class Client(object):
         self.channel = channel
         self.retry_timeout = timedelta(seconds=retry_timeout)
         self.requests_kwargs = requests_kwargs or {}
-        headers = self.request_kwargs.pop('headers', {})
+        headers = self.requests_kwargs.pop('headers', {})
         headers.update({"User-Agent": _USER_AGENT})        
         self.requests_kwargs.update({
             "headers": headers,


### PR DESCRIPTION
If `headers` are passed in as part of the `request_kwargs` on `Client` creation, then make sure they are not overridden as part of the dictionary `update`. 
