### PR TITLE
Increase the required version of requests.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if sys.version_info <= (2, 4):
 
 
 requirements = [
-    'requests>=2.11.1,<3.0',
+    'requests>=2.20.0,<3.0',
 ]
 
 setup(name='googlemaps',


### PR DESCRIPTION
Versions of the requests library prior to 2.20.0 have a known
security vulnerability (CVE-2018-18074).