### PR TITLE
Include tests in sdist pypi tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE README.md
+recursive-include googlemaps/test *.py
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
This allows distributors to test basical sanity of their stack with googlemaps package.