### PR TITLE
Parameter session_token in places_autocomplete should be optional

### DIFF
--- a/googlemaps/places.py
+++ b/googlemaps/places.py
@@ -435,7 +435,7 @@ def places_photo(client, photo_reference, max_width=None, max_height=None):
     return response.iter_content()
 
 
-def places_autocomplete(client, input_text, session_token, offset=None,
+def places_autocomplete(client, input_text, session_token=None, offset=None,
                         location=None, radius=None, language=None, types=None,
                         components=None, strict_bounds=False):
     """

--- a/googlemaps/test/test_places.py
+++ b/googlemaps/test/test_places.py
@@ -171,7 +171,7 @@ class PlacesTest(_test.TestCase):
 
         session_token = places_autocomplete_session_token()
 
-        self.client.places_autocomplete('Google', session_token, offset=3,
+        self.client.places_autocomplete('Google', session_token=session_token, offset=3,
                                         location=self.location,
                                         radius=self.radius,
                                         language=self.language,


### PR DESCRIPTION
The official docs of the Places Autocomplete API:

https://developers.google.com/places/web-service/autocomplete

have the `sessiontoken` parameter as optional.

<img width="921" alt="Screenshot 2019-08-07 13 08 12" src="https://user-images.githubusercontent.com/164460/62654343-767e8b80-b914-11e9-8e4b-54cd776988ff.png">

However, the `places_autocomplete` function has it as required:

https://github.com/googlemaps/google-maps-services-python/blob/6d1a2b84fbd76a46a87bea9a626e087059589997/googlemaps/places.py#L438-L440

I think it should be optional to be consistent with the API, and to avoid having the users to generate a session token when they don't need to identify an autocomplete session for billing purposes.