### PR TITLE
automate upload to pypi with travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,3 +28,4 @@ deploy:
     python: '3.6'
   provider: pypi
   distributions: 'sdist bdist_wheel'
+  user: __token__

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,11 @@ install:
 
 script:
 - python3 -m nox --session "$NOXSESSION"
+
+deploy:
+  on:
+    repo: googlemaps/google-maps-services-python
+    branch: pypi
+    python: '3.6'
+  provider: pypi
+  distributions: 'sdist bdist_wheel'

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ script:
 deploy:
   on:
     repo: googlemaps/google-maps-services-python
-    branch: pypi
-    python: '3.6'
+    tag: true
+    python: '3.6'  # only run this deploy once with python 3.6
   provider: pypi
   distributions: 'sdist bdist_wheel'
-  user: __token__
+  user: __token__  # api token encrypted within travis
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,6 @@ deploy:
   provider: pypi
   distributions: 'sdist bdist_wheel'
   user: __token__
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ directions_result = gmaps.directions("Sydney Town Hall",
                                      departure_time=now)
 ```
 
-For more usage examples, check out [the tests](googlemaps/test/).
+For more usage examples, check out [the tests][tests].
 
 ## Features
 
@@ -196,3 +196,4 @@ instead of an API key.
 
 [issues]: https://github.com/googlemaps/google-maps-services-python/issues
 [contrib]: https://github.com/googlemaps/google-maps-services-python/blob/master/CONTRIB.md
+[tests]: https://github.com/googlemaps/google-maps-services-python/tree/master/googlemaps/test

--- a/README.md
+++ b/README.md
@@ -175,11 +175,6 @@ instead of an API key.
     # Generating documentation
     $ nox -e docs
 
-    # Uploading a new release
-    $ easy_install wheel twine
-    $ python setup.py sdist bdist_wheel
-    $ twine upload dist/*
-
     # Copy docs to gh-pages
     $ nox -e docs && mv docs/_build/html generated_docs && git clean -Xdi && git checkout gh-pages
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with io.open("README.md", encoding="utf8") as f:
 
 setup(
     name="googlemaps",
-    version="3.0.3rc1",
+    version="3.0.2",
     description="Python client library for Google Maps Platform",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with io.open("README.md", encoding="utf8") as f:
 
 setup(
     name="googlemaps",
-    version="3.0.2",
+    version="3.0.3rc1",
     description="Python client library for Google Maps Platform",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
closes #295 

This deploys to pypi on tagged releases using the deploy providers of travis. See https://docs.travis-ci.com/user/deployment/pypi/ for more information.

I created a release candidate version `3.0.3rc1` for testing, https://pypi.org/project/googlemaps/3.0.3rc1/, since test.pypi.org has a squatter on googlemaps, https://test.pypi.org/project/googlemaps/.