### PR TITLE
explicitly truncate float precision in format_float

### DIFF
--- a/googlemaps/convert.py
+++ b/googlemaps/convert.py
@@ -47,6 +47,7 @@ def format_float(arg):
     format_float(40.001) -> "40.001"
     format_float(40.0010) -> "40.001"
     format_float(40.000000001) -> "40"
+    format_float(40.000000009) -> "40.00000001"
 
     :param arg: The lat or lng float.
     :type arg: float

--- a/googlemaps/test/test_convert.py
+++ b/googlemaps/test/test_convert.py
@@ -19,6 +19,7 @@
 
 import datetime
 import unittest
+import pytest
 
 from googlemaps import convert
 
@@ -152,3 +153,18 @@ class ConvertTest(unittest.TestCase):
         points = convert.decode_polyline(test_polyline)
         actual_polyline = convert.encode_polyline(points)
         self.assertEqual(test_polyline, actual_polyline)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (40, "40"),
+        (40.0, "40"),
+        (40.1, "40.1"),
+        (40.00000001, "40.00000001"),
+        (40.000000009, "40.00000001"),
+        (40.000000001, "40"),
+    ],
+)
+def test_format_float(value, expected):
+    assert convert.format_float(value) == expected

--- a/googlemaps/test/test_distance_matrix.py
+++ b/googlemaps/test/test_distance_matrix.py
@@ -80,8 +80,8 @@ class DistanceMatrixTest(_test.TestCase):
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual('https://maps.googleapis.com/maps/api/distancematrix/json?'
                             'key=%s&origins=Bobcaygeon+ON%%7C41.43206%%2C-81.38992&'
-                            'destinations=43.012486%%2C-83.696415%%7C42.886386%%2C'
-                            '-78.878163' % self.key,
+                            'destinations=43.012486%%2C-83.6964149%%7C42.8863855%%2C'
+                            '-78.8781627' % self.key,
                             responses.calls[0].request.url)
 
     @responses.activate

--- a/googlemaps/test/test_geocoding.py
+++ b/googlemaps/test/test_geocoding.py
@@ -59,7 +59,7 @@ class GeocodingTest(_test.TestCase):
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual('https://maps.googleapis.com/maps/api/geocode/json?'
-                            'latlng=-33.867487%%2C151.20699&key=%s' % self.key,
+                            'latlng=-33.8674869,151.2069902&key=%s' % self.key,
                             responses.calls[0].request.url)
 
     @responses.activate


### PR DESCRIPTION
Python is defaulting to 6 decimal places. As #277 shows, using 7 decimal places will lead to different results. 8 decimal places is probably more than we need. 

https://en.wikipedia.org/wiki/Decimal_degrees#Precision

I'll wait to fix tests depending on 7 or 8 decimal places.

closes #277