### PR TITLE
fix(manifest): include changelog in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE README.md
+include CHANGELOG.md LICENSE README.md
 recursive-include googlemaps/test *.py
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
currently MANIFEST.in does not include CHANGELOG.md, which causes pip
install to fail.

Traceback:

```python-traceback
Traceback (most recent call last):
	File "<string>", line 1, in <module>
	File "/tmp/pip-install-QBfwr4/googlemaps/setup.py", line 18, in <module>
		with io.open("CHANGELOG.md", encoding="utf8") as f:
IOError: [Errno 2] No such file or directory: 'CHANGELOG.md'
```