### PR TITLE
Always return a string in APIError.__str__

### DIFF
--- a/googlemaps/exceptions.py
+++ b/googlemaps/exceptions.py
@@ -27,7 +27,7 @@ class ApiError(Exception):
 
     def __str__(self):
         if self.message is None:
-            return self.status
+            return str(self.status)
         else:
             return "%s (%s)" % (self.status, self.message)
 


### PR DESCRIPTION
If this is not wrapped in `str` it returns an `int` when the `status_code` is passed as the `status`.