### PR TITLE
fix: use timezone-aware timestamp() instead of timetuple()

### DIFF
--- a/googlemaps/convert.py
+++ b/googlemaps/convert.py
@@ -28,8 +28,6 @@
     # '-33.8674869,151.2069902'
 """
 
-import time as _time
-
 
 def format_float(arg):
     """Formats a float value to be as short as possible.
@@ -187,8 +185,8 @@ def time(arg):
     :type arg: datetime.datetime or int
     """
     # handle datetime instances.
-    if _has_method(arg, "timetuple"):
-        arg = _time.mktime(arg.timetuple())
+    if _has_method(arg, "timestamp"):
+        arg = arg.timestamp()
 
     if isinstance(arg, float):
         arg = int(arg)


### PR DESCRIPTION
fixes issue where [`convert.time()`](https://github.com/googlemaps/google-maps-services-python/blob/master/googlemaps/convert.py#L179) ignores timezone in the datetime object.

- **current implementation:**

```python3
times = [
     datetime(2020, 3, 14, 8, 0, tzinfo=timezone.utc),
     datetime(2020, 3, 14, 9, 0, tzinfo=timezone(timedelta(hours=1))),
     datetime(2020, 3, 14, 8, 0, tzinfo=timezone(timedelta(hours=1)))
]
for time in times:
	print(convert.time(time))
```

- **output:**

```
1584153000
1584156600
1584153000
```

technically, as @atollena describes, the first two times should be considered to be the same, whereas the third datetime instance is expected be an hour behind the first two instances. but by using `timetuple()`, the specified timezone is ignored. so using the `timestamp()` method instead of `timetuple()` ensures that the specified timezone data is respected:

- **new implementation (assuming the same list of times from before):**

```python3
for time in times:
	print(convert.time(time))
```

- **output:**

```
1584172800
1584172800
1584169200
```

here, the specified timezone data is respected, and as expected the third datetime instance is 3600 seconds behind the first two instances.

since the support for python2.7 has now been dropped, this can safely be included in the package.

Fixes #185 