### PR TITLE
build: test and build docs with python3

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="2.7")
+@nox.session(python=SUPPORTED_PY_VERSIONS)
 def docs(session):
     _install_dev_packages(session)
     _install_doc_dependencies(session)

--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python=SUPPORTED_PY_VERSIONS)
+@nox.session(python="3.6")
 def docs(session):
     _install_dev_packages(session)
     _install_doc_dependencies(session)


### PR DESCRIPTION
currently, docs build fails with the following error:

```
ERROR: Package 'googlemaps' requires a different Python: 2.7.12 not in '>=3.5'
```

using python3 should fix this issue