### PR TITLE
docs: Adding docs.yml workflow to update docs on a new tag.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,12 +28,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Python
-      uses: "actions/setup-python@v1"
+      uses: "actions/setup-python@v3"
       with:
-        python-version: "3.6"
+        python-version: "3.9"
 
     - name: Install dependencies
       run: ./.github/scripts/install.sh
@@ -51,7 +51,7 @@ jobs:
         cd $GITHUB_WORKSPACE && git checkout gh-pages && tar xvf ~/docs.tar
 
     - name: PR Changes
-      uses: peter-evans/create-pull-request@v2
+      uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
         commit-message: 'docs: Update docs'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,63 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A workflow that pushes artifacts to Sonatype
+name: Publish
+
+on:
+  push:
+    tags:
+      - '*'
+  repository_dispatch:
+    types: [docs]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: "actions/setup-python@v1"
+      with:
+        python-version: "3.6"
+
+    - name: Install dependencies
+      run: ./.github/scripts/install.sh
+
+    - name: Generate docs
+      run: python3 -m nox --session docs
+
+    - name: Update gh-pages branch with docs
+      run: |
+        echo "Creating tar for generated docs"
+        cd ./docs/_build/html && tar cvf ~/docs.tar .
+
+        echo "Unpacking tar into gh-pages branch"
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+        cd $GITHUB_WORKSPACE && git checkout gh-pages && tar xvf ~/docs.tar
+
+    - name: PR Changes
+      uses: peter-evans/create-pull-request@v2
+      with:
+        token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
+        commit-message: 'docs: Update docs'
+        committer: googlemaps-bot <googlemaps-bot@google.com>
+        author: googlemaps-bot <googlemaps-bot@google.com>
+        title: 'docs: Update docs'
+        body: |
+            Updated GitHub pages with latest from `python3 -m nox --session docs`.
+        branch: googlemaps-bot/update_gh_pages


### PR DESCRIPTION
Adding a GitHub workflow to trigger regenerating docs when a new
tag is pushed. Once the docs have been generated, a new PR will be
opened against the `gh-pages` branch.

Resolves #348
