### PR TITLE
Allow overriding base_url on Client object initialization

### DIFF
--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -53,7 +53,8 @@ class Client(object):
                  timeout=None, connect_timeout=None, read_timeout=None,
                  retry_timeout=60, requests_kwargs=None,
                  queries_per_second=50, channel=None,
-                 retry_over_query_limit=True, experience_id=None):
+                 retry_over_query_limit=True, experience_id=None, 
+                 base_url=_DEFAULT_BASE_URL):
         """
         :param key: Maps API key. Required, unless "client_id" and
             "client_secret" are set. Most users should use an API key.
@@ -115,6 +116,10 @@ class Client(object):
             implemented. See the official requests docs for more info:
             http://docs.python-requests.org/en/latest/api/#main-interface
         :type requests_kwargs: dict
+        
+        :param base_url: The base URL for all requests. Defaults to the Maps API
+            server. Should not have a trailing slash.
+        :type base_url: string
 
         """
         if not key and not (client_secret and client_id):
@@ -167,6 +172,7 @@ class Client(object):
         self.retry_over_query_limit = retry_over_query_limit
         self.sent_times = collections.deque("", queries_per_second)
         self.set_experience_id(experience_id)
+        self.base_url = base_url
 
     def set_experience_id(self, *experience_id_args):
         """Sets the value for the HTTP header field name
@@ -204,7 +210,7 @@ class Client(object):
         self.requests_kwargs["headers"] = headers
 
     def _request(self, url, params, first_request_time=None, retry_counter=0,
-             base_url=_DEFAULT_BASE_URL, accepts_clientid=True,
+             base_url=None, accepts_clientid=True,
              extract_body=None, requests_kwargs=None, post_json=None):
         """Performs HTTP GET/POST with credentials, returning the body as
         JSON.
@@ -246,6 +252,9 @@ class Client(object):
             exceute a request.
         """
 
+        if base_url is None:
+            base_url = self.base_url
+            
         if not first_request_time:
             first_request_time = datetime.now()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -209,7 +209,22 @@ class ClientTest(TestCase):
         self.assertEqual(e.exception.status_code, 404)
 
     @responses.activate
-    def test_host_override(self):
+    def test_host_override_on_init(self):
+        responses.add(
+            responses.GET,
+            "https://foo.com/bar",
+            body='{"status":"OK","results":[]}',
+            status=200,
+            content_type="application/json",
+        )
+
+        client = googlemaps.Client(key="AIzaasdf", base_url="https://foo.com")
+        client._get("/bar", {})
+
+        self.assertEqual(1, len(responses.calls))
+
+    @responses.activate
+    def test_host_override_per_request(self):
         responses.add(
             responses.GET,
             "https://foo.com/bar",


### PR DESCRIPTION
It's currently impossible to override _DEFAULT_BASE_URL because it's part of `_request`'s signature. 

This PR adds a `base_url` keyword argument to the `Client` object constructor and saves it in an instance variable. `_request` then uses the instance variable when making the request (unless it's been provided with its own override)

Overriding the base URL is necessary when setting up a mock server for testing purposes for example.

This issue was raised before in https://github.com/googlemaps/google-maps-services-python/pull/204 but ended up not being addressed.
