### PR TITLE
docs: fix params for find_place.

### DIFF
--- a/googlemaps/places.py
+++ b/googlemaps/places.py
@@ -123,10 +123,9 @@ def find_place(
                   or 'phonenumber'.
     :type input_type: string
 
-    :param fields: The fields specifying the types of place data to return,
-                   separated by a comma. For full details see:
+    :param fields: The fields specifying the types of place data to return. For full details see:
                    https://developers.google.com/places/web-service/search#FindPlaceRequests
-    :type input: list
+    :type fields: list
 
     :param location_bias: Prefer results in a specified area, by specifying
                           either a radius plus lat/lng, or two lat/lng pairs


### PR DESCRIPTION
In the documentation for find_place, it says that `fields` parameter is "separated by a comma",
but it is in fact a list, instead of a comma separated string. Perhaps I just misunderstood
what it meant? I think removing the "separated by a comma" would be clearer.

The find_place documentation also says that the type for `input` is list, and
there's no type specified for `fields`. In reality (upon reading the code),
I noticed that the `input` is a string, and `fields` is a list type.

I've updated the documentation to reflect correct types.

Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #370 🦕
