### PR TITLE
docs: fix simple typo, preffix -> prefix

### DIFF
--- a/googlemaps/directions.py
+++ b/googlemaps/directions.py
@@ -33,7 +33,7 @@ def directions(client, origin, destination,
 
     :param destination: The address or latitude/longitude value from which
         you wish to calculate directions. You can use a place_id as destination
-        by putting 'place_id:' as a preffix in the passing parameter.
+        by putting 'place_id:' as a prefix in the passing parameter.
     :type destination: string, dict, list, or tuple
 
     :param mode: Specifies the mode of transport to use when calculating


### PR DESCRIPTION
There is a small typo in googlemaps/directions.py.

Should read `prefix` rather than `preffix`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md