### PR TITLE
Add parameter 'origin' to places autocomplete

### DIFF
--- a/googlemaps/places.py
+++ b/googlemaps/places.py
@@ -513,6 +513,7 @@ def places_autocomplete(
     input_text,
     session_token=None,
     offset=None,
+    origin=None,
     location=None,
     radius=None,
     language=None,
@@ -536,6 +537,12 @@ def places_autocomplete(
                    if the input is 'Google' and the offset is 3, the
                    service will match on 'Goo'.
     :type offset: int
+
+    :param origin: The origin point from which to calculate straight-line distance
+                    to the destination (returned as distance_meters).
+                    If this value is omitted, straight-line distance will
+                    not be returned.
+    :type origin: string, dict, list, or tuple
 
     :param location: The latitude/longitude value for which you wish to obtain the
                      closest, human-readable address.
@@ -570,6 +577,7 @@ def places_autocomplete(
         input_text,
         session_token=session_token,
         offset=offset,
+        origin=origin,
         location=location,
         radius=radius,
         language=language,
@@ -623,6 +631,7 @@ def _autocomplete(
     input_text,
     session_token=None,
     offset=None,
+    origin=None,
     location=None,
     radius=None,
     language=None,
@@ -641,6 +650,8 @@ def _autocomplete(
         params["sessiontoken"] = session_token
     if offset:
         params["offset"] = offset
+    if origin:
+        params["origin"] = convert.latlng(origin)
     if location:
         params["location"] = convert.latlng(location)
     if radius:

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -212,6 +212,7 @@ class PlacesTest(TestCase):
             "Google",
             session_token=session_token,
             offset=3,
+            origin=self.location,
             location=self.location,
             radius=self.radius,
             language=self.language,
@@ -223,6 +224,7 @@ class PlacesTest(TestCase):
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual(
             "%s?components=country%%3Aau&input=Google&language=en-AU&"
+            "origin=-33.86746%%2C151.20709&"
             "location=-33.86746%%2C151.20709&offset=3&radius=100&"
             "strictbounds=true&types=geocode&key=%s&sessiontoken=%s"
             % (url, self.key, session_token),


### PR DESCRIPTION
Fairly simple PR that adds `origin` parameter to the [places autocomplete](https://developers.google.com/places/web-service/autocomplete#place_autocomplete_requests) request.