### PR TITLE
Make Places "textsearch" query parameter optional

### DIFF
--- a/googlemaps/places.py
+++ b/googlemaps/places.py
@@ -168,7 +168,7 @@ def find_place(
 
 def places(
     client,
-    query,
+    query=None,
     location=None,
     radius=None,
     language=None,


### PR DESCRIPTION
The `query` parameter in the Places' `textsearch` API should be optional. Both as a fix for #395, but also more generally because the actual API supports calls without specifying the parameter.

For example: `https://maps.googleapis.com/maps/api/place/textsearch/json?type=point_of_interest&location=43.8789781,-79.9714529&radius=10000&key={{ key }}`

No `query` parameter is specified, yet the request is completed successfully with no error and a result set. 

Fixes #395 🦕
