### PR TITLE
feat: Geocode by place id

### DIFF
--- a/googlemaps/geocoding.py
+++ b/googlemaps/geocoding.py
@@ -19,7 +19,7 @@
 from googlemaps import convert
 
 
-def geocode(client, address=None, components=None, bounds=None, region=None,
+def geocode(client, address=None, place_id=None, components=None, bounds=None, region=None,
             language=None):
     """
     Geocoding is the process of converting addresses
@@ -29,6 +29,10 @@ def geocode(client, address=None, components=None, bounds=None, region=None,
 
     :param address: The address to geocode.
     :type address: string
+
+    :param place_id: A textual identifier that uniquely identifies a place,
+        returned from a Places search.
+    :type place_id: string
 
     :param components: A component filter for which you wish to obtain a
         geocode, for example: ``{'administrative_area': 'TX','country': 'US'}``
@@ -52,6 +56,9 @@ def geocode(client, address=None, components=None, bounds=None, region=None,
 
     if address:
         params["address"] = address
+
+    if place_id:
+        params["place_id"] = place_id
 
     if components:
         params["components"] = convert.components(components)

--- a/tests/test_geocoding.py
+++ b/tests/test_geocoding.py
@@ -202,6 +202,25 @@ class GeocodingTest(TestCase):
         )
 
     @responses.activate
+    def test_geocode_place_id(self):
+        responses.add(
+            responses.GET,
+            "https://maps.googleapis.com/maps/api/geocode/json",
+            body='{"status":"OK","results":[]}',
+            status=200,
+            content_type="application/json",
+        )
+
+        results = self.client.geocode(place_id="ChIJeRpOeF67j4AR9ydy_PIzPuM")
+
+        self.assertEqual(1, len(responses.calls))
+        self.assertURLEqual(
+            "https://maps.googleapis.com/maps/api/geocode/json?"
+            "key=%s&place_id=ChIJeRpOeF67j4AR9ydy_PIzPuM" % self.key,
+            responses.calls[0].request.url,
+            )
+
+    @responses.activate
     def test_simple_reverse_geocode(self):
         responses.add(
             responses.GET,


### PR DESCRIPTION
Geocode endpoint accepts a `place_id` param as an alternative to geocode
Google docs: https://developers.google.com/maps/documentation/geocoding/requests-places-geocoding

Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
