### PR TITLE
Fix issue #449: Broken support for Python 3.5

### DIFF
--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -177,7 +177,7 @@ class Client:
             "verify": True,  # NOTE(cbro): verify SSL certs.
         })
         
-        self.queries_quota : int
+        self.queries_quota
         self.queries_per_second = queries_per_second
         self.queries_per_minute = queries_per_minute
         try: 


### PR DESCRIPTION
Removes the type annotation, which is not valid syntax in Python 3.5

Fixes #449
