### PR TITLE
Trigger retry mechanism on  status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ dist/
 .coverage
 .nox
 env
+.env
 googlemaps.egg-info
 *.egg
 .vscode/

--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -366,6 +366,9 @@ class Client:
             raise googlemaps.exceptions._OverQueryLimit(
                 api_status, body.get("error_message"))
 
+        if api_status == "INVALID_REQUEST":
+            raise googlemaps.exceptions._RetriableRequest()
+
         raise googlemaps.exceptions.ApiError(api_status,
                                              body.get("error_message"))
 


### PR DESCRIPTION
Triggering the retry mechanism on invalid requests due to inconsistent behavior in Google Maps API, which is described in issue #366.

The side effect is that if wrong parameters are provided request won't fail on the first try but will go through a retry mechanism. 

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #366 🦕
