### PR TITLE
feat: find_place: Add location_restriction parameter

### DIFF
--- a/googlemaps/places.py
+++ b/googlemaps/places.py
@@ -96,7 +96,7 @@ DEPRECATED_FIELDS_MESSAGE = (
 
 
 def find_place(
-    client, input, input_type, fields=None, location_bias=None, language=None
+    client, input, input_type, fields=None, location_bias=None, location_restriction=None, language=None
 ):
     """
     A Find Place request takes a text input, and returns a place.
@@ -120,6 +120,12 @@ def find_place(
                           representing the points of a rectangle. See:
                           https://developers.google.com/places/web-service/search#FindPlaceRequests
     :type location_bias: string
+
+    :param location_restriction: Restrict results to a specified area, by specifying either
+                                 a radius plus lat/lng, or two lat/lng pairs representing the
+                                 points of a rectangle. See:
+                                 https://developers.google.com/places/web-service/search#FindPlaceRequests
+    :type location_restriction: string
 
     :param language: The language in which to return results.
     :type language: string
@@ -160,6 +166,13 @@ def find_place(
         if location_bias.split(":")[0] not in valid:
             raise ValueError("location_bias should be prefixed with one of: %s" % valid)
         params["locationbias"] = location_bias
+
+    if location_restriction:
+        valid = ["circle", "rectangle"]
+        if location_restriction.split(":")[0] not in valid:
+            raise ValueError("location_restriction should be prefixed with one of: %s" % valid)
+        params["locationrestriction"] = location_restriction
+
     if language:
         params["language"] = language
 


### PR DESCRIPTION
Google Maps API Find Place requests now support a location restriction parameter which limit results to a specified area. This is unlike the location bias parameter which prefers results in a specified area. The location restriction parameter can be set by specifying either a radius plus lat/lng, or two lat/lng pairs representing the points of a rectangle.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes https://github.com/googlemaps/google-maps-services-python/issues/464 🦕
