### PR TITLE
chore: update release action dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Cleanup old dist
       run: rm -rf googlemaps-* dist/
     - name: Semantic Release
-      uses: cycjimmy/semantic-release-action@3
+      uses: cycjimmy/semantic-release-action@v3
       with:
         semantic_version: 19
         extra_plugins: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Semantic Release
       uses: cycjimmy/semantic-release-action@3
       with:
+        semantic_version: 19
         extra_plugins: |
           "@semantic-release/commit-analyzer"
           "@semantic-release/release-notes-generator"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,11 @@ jobs:
       PYTHONDONTWRITEBYTECODE: 1
     steps:
     - name: Setup Python
-      uses: "actions/setup-python@v1"
+      uses: "actions/setup-python@v3"
       with:
         python-version: "3.9"
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}
     - name: Install dependencies
@@ -37,7 +37,7 @@ jobs:
     - name: Cleanup old dist
       run: rm -rf googlemaps-* dist/
     - name: Semantic Release
-      uses: cycjimmy/semantic-release-action@v2
+      uses: cycjimmy/semantic-release-action@3
       with:
         extra_plugins: |
           "@semantic-release/commit-analyzer"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,4 +51,6 @@ jobs:
     needs: [matrix]
     runs-on: ubuntu-latest
     steps:
-    - run: echo "Test matrix finished"
+    - run: |
+        echo "Test matrix finished";
+        exit 1;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,4 +53,4 @@ jobs:
     steps:
     - run: |
         echo "Test matrix finished";
-        exit 1;
+        exit 0;


### PR DESCRIPTION
Outdated dependencies cause release action to fail such as in this [recent run](https://github.com/googlemaps/google-maps-services-python/actions/runs/3991370751).