### PR TITLE
feat: add new place details fields and reviews request modifiers

### DIFF
--- a/googlemaps/places.py
+++ b/googlemaps/places.py
@@ -98,7 +98,8 @@ PLACES_DETAIL_FIELDS_ATMOSPHERE = {
     "price_level",
     "rating",
     "reservable",
-    "review",
+    "review",  # prefer "reviews" to match API documentation
+    "reviews",
     "serves_beer",
     "serves_breakfast",
     "serves_brunch",
@@ -116,7 +117,7 @@ PLACES_DETAIL_FIELDS = (
     ^ PLACES_DETAIL_FIELDS_ATMOSPHERE
 )
 
-DEPRECATED_FIELDS = {"permanently_closed"}
+DEPRECATED_FIELDS = {"permanently_closed", "review"}
 DEPRECATED_FIELDS_MESSAGE = (
     "Fields, %s, are deprecated. "
     "Read more at https://developers.google.com/maps/deprecations."

--- a/googlemaps/places.py
+++ b/googlemaps/places.py
@@ -52,35 +52,63 @@ PLACES_FIND_FIELDS = (
     ^ PLACES_FIND_FIELDS_ATMOSPHERE
 )
 
-PLACES_DETAIL_FIELDS_BASIC = {"address_component",
-        "adr_address",
-        "business_status",
-        "formatted_address",
-        "geometry",
-        "geometry/location",
-        "geometry/location/lat",
-        "geometry/location/lng",
-        "geometry/viewport",
-        "geometry/viewport/northeast",
-        "geometry/viewport/northeast/lat",
-        "geometry/viewport/northeast/lng",
-        "geometry/viewport/southwest",
-        "geometry/viewport/southwest/lat",
-        "geometry/viewport/southwest/lng",
-        "icon",
-        "name",
-        "permanently_closed",
-        "photo",
-        "place_id",
-        "plus_code",
-        "type",
-        "url",
-        "utc_offset",
-        "vicinity",}
+PLACES_DETAIL_FIELDS_BASIC = {
+    "address_component",
+    "adr_address",
+    "business_status",
+    "formatted_address",
+    "geometry",
+    "geometry/location",
+    "geometry/location/lat",
+    "geometry/location/lng",
+    "geometry/viewport",
+    "geometry/viewport/northeast",
+    "geometry/viewport/northeast/lat",
+    "geometry/viewport/northeast/lng",
+    "geometry/viewport/southwest",
+    "geometry/viewport/southwest/lat",
+    "geometry/viewport/southwest/lng",
+    "icon",
+    "name",
+    "permanently_closed",
+    "photo",
+    "place_id",
+    "plus_code",
+    "type",
+    "url",
+    "utc_offset",
+    "vicinity",
+    "wheelchair_accessible_entrance"
+}
 
-PLACES_DETAIL_FIELDS_CONTACT = {"formatted_phone_number", "international_phone_number", "opening_hours", "website"}
+PLACES_DETAIL_FIELDS_CONTACT = {
+    "formatted_phone_number",
+    "international_phone_number",
+    "opening_hours",
+    "current_opening_hours",
+    "secondary_opening_hours",
+    "website",
+}
 
-PLACES_DETAIL_FIELDS_ATMOSPHERE = {"editorial_summary","price_level", "rating", "review", "user_ratings_total"}
+PLACES_DETAIL_FIELDS_ATMOSPHERE = {
+    "curbside_pickup",
+    "delivery",
+    "dine_in",
+    "editorial_summary",
+    "price_level",
+    "rating",
+    "reservable",
+    "review",
+    "serves_beer",
+    "serves_breakfast",
+    "serves_brunch",
+    "serves_dinner",
+    "serves_lunch",
+    "serves_vegetarian_food",
+    "serves_wine",
+    "takeout",
+    "user_ratings_total"
+}
 
 PLACES_DETAIL_FIELDS = (
     PLACES_DETAIL_FIELDS_BASIC
@@ -402,7 +430,8 @@ def place(
     session_token=None,
     fields=None,
     language=None,
-    reviews_sort="most_relevant"
+    reviews_no_translations=False,
+    reviews_sort="most_relevant",
 ):
     """
     Comprehensive details for an individual place.
@@ -422,6 +451,9 @@ def place(
 
     :param language: The language in which to return results.
     :type language: string
+
+    :param reviews_no_translations: Specify reviews_no_translations=True to disable translation of reviews; reviews_no_translations=False (default) enables translation of reviews.
+    :type reviews_no_translations: bool
 
     :param reviews_sort: The sorting method to use when returning reviews.
                          Can be set to most_relevant (default) or newest.
@@ -455,6 +487,8 @@ def place(
         params["language"] = language
     if session_token:
         params["sessiontoken"] = session_token
+    if reviews_no_translations:
+        params["reviews_no_translations"] = "true"
     if reviews_sort:
         params["reviews_sort"] = reviews_sort
 

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -166,14 +166,14 @@ class PlacesTest(TestCase):
             fields=["business_status", "geometry/location",
                     "place_id", "reviews"],
             language=self.language,
-            reviews_no_translation=True,
+            reviews_no_translations=True,
             reviews_sort="newest",
         )
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual(
             "%s?language=en-AU&placeid=ChIJN1t_tDeuEmsRUsoyG83frY4"
-            "&reviews_no_translation=true&reviews_sort=newest"
+            "&reviews_no_translations=true&reviews_sort=newest"
             "&key=%s&fields=business_status,geometry/location,place_id,reviews"
             % (url, self.key),
             responses.calls[0].request.url,

--- a/tests/test_places.py
+++ b/tests/test_places.py
@@ -36,7 +36,6 @@ class PlacesTest(TestCase):
         self.type = "liquor_store"
         self.language = "en-AU"
         self.region = "AU"
-        self.reviews_sort="newest"
         self.radius = 100
 
     @responses.activate
@@ -164,15 +163,18 @@ class PlacesTest(TestCase):
 
         self.client.place(
             "ChIJN1t_tDeuEmsRUsoyG83frY4",
-            fields=["business_status", "geometry/location", "place_id"],
+            fields=["business_status", "geometry/location",
+                    "place_id", "reviews"],
             language=self.language,
-            reviews_sort=self.reviews_sort,
+            reviews_no_translation=True,
+            reviews_sort="newest",
         )
 
         self.assertEqual(1, len(responses.calls))
         self.assertURLEqual(
-            "%s?reviews_sort=newest&language=en-AU&placeid=ChIJN1t_tDeuEmsRUsoyG83frY4"
-            "&key=%s&fields=business_status,geometry/location,place_id"
+            "%s?language=en-AU&placeid=ChIJN1t_tDeuEmsRUsoyG83frY4"
+            "&reviews_no_translation=true&reviews_sort=newest"
+            "&key=%s&fields=business_status,geometry/location,place_id,reviews"
             % (url, self.key),
             responses.calls[0].request.url,
         )


### PR DESCRIPTION
New Place Details fields and request parameters were announced in [this blog post](https://cloud.google.com/blog/products/maps-platform/help-users-discover-more-new-places-api-updates) for the Places API.

This PR builds upon PRs #471 and #468 to complete the addition of the new fields and reviews-related request parameters to the Python client.

Added:

- reviews_no_translation
- reviews_sort
- fields
  - curbside_pickup
  - current_opening_hours
  - delivery
  - dine_in
  - reservable
  - reviews (deprecates `review` field in favor of [documented plural](https://developers.google.com/maps/documentation/places/web-service/place-data-fields))
  - secondary_opening_hours
  - serves_beer
  - serves_breakfast
  - serves_brunch
  - serves_dinner
  - serves_lunch
  - serves_vegetarian_food
  - serves_wine
  - takeout
  - wheelchair_accessible_entrance