### PR TITLE
Updated encoding

### DIFF
--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -516,19 +516,18 @@ def urlencode_params(params):
 
 
 try:
-    unicode
     # NOTE(cbro): `unicode` was removed in Python 3. In Python 3, NameError is
     # raised here, and caught below.
 
     def normalize_for_urlencode(value):
-        """(Python 2) Converts the value to a `str` (raw bytes)."""
-        if isinstance(value, unicode):
-            return value.encode('utf8')
-
-        if isinstance(value, str):
-            return value
-
-        return normalize_for_urlencode(str(value))
+        if(sys.version[0]<=2):
+            """(Python 2) Converts the value to a `str` (raw bytes)."""
+            if isinstance(value, str):
+                return value
+            else:
+                return value.encode('utf8')
+        else:
+            return value.encode('utf-8')
 
 except NameError:
     def normalize_for_urlencode(value):

--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -520,7 +520,7 @@ try:
     # raised here, and caught below.
 
     def normalize_for_urlencode(value):
-        if(sys.version[0]<=2):
+        if(int(sys.version[0])<=2):
             """(Python 2) Converts the value to a `str` (raw bytes)."""
             if isinstance(value, str):
                 return value

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [tool:pytest]
-addopts = -rsxX --cov=googlemaps --cov-report=
+addopts = -rsxX 
 
 [coverage:run]
 omit = 


### PR DESCRIPTION
I have made encoding (in client) compatible with both Python 2 and Python 3. The existing encoding was the correct approach for Py2, but was not appropriate for python3, because it had removed the data type. So as to not cause any issues with the python3 interpreter, urlencode_params() checks for a str type instead of unicode. 
Python3 shouldn't really need encoding here, but unlike 2, it will handle unnecessary encoding fine - so I have enforced it to always encode for python3