### PR TITLE
fix(places): correct typo in places detail fields

### DIFF
--- a/googlemaps/places.py
+++ b/googlemaps/places.py
@@ -53,7 +53,7 @@ PLACES_FIND_FIELDS = (
 )
 
 PLACES_DETAIL_FIELDS_BASIC = {
-    "address_component",
+    "address_components",
     "adr_address",
     "business_status",
     "formatted_address",


### PR DESCRIPTION
Currently there is a typo in googlemaps/places.py that prevents the retrieval ot the address components array.

This  commit fixes the above mentioned typo.