### PR TITLE
fix: allow calls with channels along with api key authentication

### DIFF
--- a/googlemaps/client.py
+++ b/googlemaps/client.py
@@ -77,7 +77,6 @@ class Client:
         :param channel: (for Maps API for Work customers) When set, a channel
             parameter with this value will be added to the requests.
             This can be used for tracking purpose.
-            Can only be used with a Maps API client ID.
         :type channel: str
 
         :param timeout: Combined connect and read timeout for HTTP requests, in
@@ -390,9 +389,10 @@ class Client:
         else:
             params = sorted(extra_params.items()) + params[:] # Take a copy.
 
+        if self.channel:
+            params.append(("channel", self.channel))
+
         if accepts_clientid and self.client_id and self.client_secret:
-            if self.channel:
-                params.append(("channel", self.channel))
             params.append(("client", self.client_id))
 
             path = "?".join([path, urlencode_params(params)])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -310,7 +310,7 @@ class ClientTest(TestCase):
         auth_url = client._generate_auth_url(
             "/test", {"param": "param"}, accepts_clientid=False
         )
-        self.assertEqual(auth_url, "/test?param=param&key=AIzaasdf")
+        self.assertEqual(auth_url, "/test?param=param&channel=MyChannel_1&key=AIzaasdf")
 
     def test_requests_version(self):
         client_args_timeout = {


### PR DESCRIPTION
I would like to suggest a fix associated with channels usage in API calls.

Since client id and client secret authentication [has become legacy](https://developers.google.com/maps/premium/authentication/client-id/url-authorization), channels are now not unique to the calls made with this method of authentication. The usage of channels without client id is even mentioned in the following lines of code that are part of the current library version:
https://github.com/googlemaps/google-maps-services-python/blob/645e07de5a27c4c858b2c0673f0dd6f23ca62d28/googlemaps/client.py#L146-L151

However, in the method __generate_auth_url_ the channel parameter is added to the authentication URL only if client id and secret were provided. Thus it is currently impossible to apply channels to calls authenticated with just API key using this library, they are simply not part of the final authentication URL as long as client id and secret weren't provided:
https://github.com/googlemaps/google-maps-services-python/blob/645e07de5a27c4c858b2c0673f0dd6f23ca62d28/googlemaps/client.py#L393-L396
